### PR TITLE
Fix: Emit %%DX header by default in dxs pack

### DIFF
--- a/src/Dx.Cli/Commands/PackCommand.cs
+++ b/src/Dx.Cli/Commands/PackCommand.cs
@@ -55,9 +55,9 @@ public sealed class PackSettings : CommandSettings
     /// Gets a value indicating whether a <c>%%DX</c> session header line should be
     /// prepended to the output, making the document a valid standalone DX document.
     /// </summary>
-    [CommandOption("--session-header")]
-    [Description("Prepend a %%DX session header to produce a valid standalone DX document.")]
-    public bool SessionHeader { get; init; }
+    [CommandOption("--no-header")]
+    [Description("Do not emit the %%DX header and %%END footer.")]
+    public bool NoHeader { get; init; }
 
     /// <summary>
     /// Gets a value indicating whether a directory tree overview should be prepended
@@ -158,8 +158,11 @@ public sealed class PackCommand : DxCommandBase<PackSettings>
 
             var sb = new StringBuilder();
 
-            if (s.SessionHeader)
-                sb.AppendLine("%%DX v1.3 author=tool");
+            if (!s.NoHeader)
+            {
+                // TODO: consider allowing custom session and author via command options
+                sb.AppendLine("%%DX v1.3 author=tool"); 
+            }
 
             var targetAbs = Path.IsPathRooted(s.Path)
                 ? s.Path
@@ -266,8 +269,10 @@ public sealed class PackCommand : DxCommandBase<PackSettings>
                 packed++;
             }
 
-            if (s.SessionHeader)
+            if (!s.NoHeader)
+            {
                 sb.AppendLine("%%END");
+            }
 
             var output = sb.ToString();
 

--- a/src/Dx.Cli/Program.cs
+++ b/src/Dx.Cli/Program.cs
@@ -96,7 +96,7 @@ app.Configure(config =>
           .WithDescription("Show session log.");
 
     config.AddCommand<PackCommand>("pack")
-          .WithDescription("Bundle files into a read-only DX document for LLM context.");
+          .WithDescription("Bundle files into a standalone DX document for LLM context.");
 
     config.AddCommand<RunCommand>("run")
           .WithDescription("Execute a command against a specific snap state.");


### PR DESCRIPTION
## Summary
Ensure `dxs pack` emits a valid DX document with a leading %%DX header by default.

## Related Issue
Closes #26

## Type of Change
- [ ] Bug fix
- [ ] Refactor
- [x] Behavioral change
- [ ] Tests
- [ ] Documentation

## Changes
- Emit %%DX header by default in pack output
- Preserve existing behavior behind an explicit opt-out flag if needed

## Invariants / Contracts
- `dxs pack` always produces a protocol-complete DX document
- Output validity does not depend on invocation context

## Verification
- `dotnet run -- pack` output includes %%DX header
- Downstream consumers accept packed output without additional flags

## Risks
- Minor compatibility change for scripts relying on header-less output

## Checklist
- [ ] Builds cleanly
- [ ] Tests pass
- [ ] Behavior documented