### PR TITLE
Refactor: Transaction Coordinator

### DIFF
--- a/src/Dx.Core/DxError.cs
+++ b/src/Dx.Core/DxError.cs
@@ -19,6 +19,13 @@ public enum DxError
     BaseMismatch,
 
     /// <summary>
+    /// A <see cref="Dx.Core.Protocol.RequestBlock"/> of type <c>run</c> returned a non-zero 
+    /// exit code. The transaction was rolled back to ensure the workspace remains in a 
+    /// passing state.
+    /// </summary>
+    RunGateFailed,
+
+    /// <summary>
     /// The specified snapshot handle does not exist in the current session.
     /// </summary>
     SnapNotFound,
@@ -87,20 +94,6 @@ public enum DxError
 /// <summary>
 /// Represents a DX-domain error, coupling an error code with a human-readable message.
 /// </summary>
-/// <remarks>
-/// <para>
-/// All DX runtime operations that encounter a domain error throw a <see cref="DxException"/>
-/// rather than a generic <see cref="Exception"/>. CLI commands catch <see cref="DxException"/>
-/// separately from unexpected exceptions and map it to the correct process exit code via
-/// <see cref="ExitCode"/>.
-/// </para>
-/// <para>
-/// Use <see cref="IsRecoverable"/> to determine whether the workspace is still in a
-/// consistent state after the error.
-/// </para>
-/// </remarks>
-/// <param name="error">The specific <see cref="DxError"/> that occurred.</param>
-/// <param name="message">A human-readable description of the error, suitable for display.</param>
 public sealed class DxException(DxError error, string message)
     : Exception(message)
 {
@@ -111,48 +104,64 @@ public sealed class DxException(DxError error, string message)
     /// Returns <see langword="true"/> when the given error code indicates a recoverable
     /// condition — one in which the workspace remains consistent and no rollback is needed.
     /// </summary>
-    /// <param name="e">The error code to classify.</param>
-    /// <returns>
-    /// <see langword="true"/> for recoverable errors; <see langword="false"/> for fatal ones.
-    /// </returns>
     public static bool IsRecoverable(DxError e) => e switch
     {
-        DxError.BaseMismatch            => true,
-        DxError.SnapNotFound            => true,
-        DxError.NoOp                    => true,
-        DxError.PathEscapesRoot         => true,
-        DxError.InvalidArgument         => true,
+        DxError.BaseMismatch => true,
+        DxError.RunGateFailed => true,
+        DxError.SnapNotFound => true,
+        DxError.NoOp => true,
+        DxError.PathEscapesRoot => true,
+        DxError.InvalidArgument => true,
         DxError.WorkspaceNotInitialized => true,
-        DxError.ParseError              => true,
-        _                               => false,
+        DxError.ParseError => true,
+        _ => false,
     };
 
     /// <summary>
-    /// Maps a <see cref="DxError"/> code to the conventional process exit code that CLI
-    /// commands should return when that error occurs.
+    /// Maps a <see cref="DxError"/> value to a conventional process exit code.
     /// </summary>
-    /// <param name="e">The error code to map.</param>
-    /// <returns>
+    /// <remarks>
+    /// <para>
+    /// Exit codes emitted by DX are stable, user‑visible contracts intended for
+    /// automation, scripting, and CI environments.
+    /// </para>
+    /// <para>
+    /// The following conventions are enforced:
+    /// </para>
     /// <list type="bullet">
-    ///   <item><description><c>0</c> — <see cref="DxError.NoOp"/> (success, no changes).</description></item>
-    ///   <item><description><c>1</c> — Fatal or session-level errors.</description></item>
-    ///   <item><description><c>2</c> — Parse, validation, or argument errors.</description></item>
-    ///   <item><description><c>3</c> — <see cref="DxError.BaseMismatch"/> (conflict).</description></item>
+    ///   <item>
+    ///     <description><c>1</c> — Run‑gate failures or fatal execution errors.</description>
+    ///   </item>
+    ///   <item>
+    ///     <description><c>2</c> — Validation or parse failures detected before execution.</description>
+    ///   </item>
+    ///   <item>
+    ///     <description><c>3</c> — Base‑mismatch conflicts that prevent safe execution.</description>
+    ///   </item>
     /// </list>
+    /// <para>
+    /// New <see cref="DxError"/> values MUST map to an existing category or
+    /// explicitly document a new exit code.
+    /// </para>
+    /// </remarks>
+    /// <returns>
+    /// A non‑zero integer representing the process exit code associated with
+    /// the supplied <see cref="DxError"/>.
     /// </returns>
     public static int ExitCode(DxError e) => e switch
     {
-        DxError.BaseMismatch                    => 3,
-        DxError.NoOp                            => 0,
-        DxError.SnapNotFound                    => 2,
-        DxError.PathEscapesRoot                 => 2,
-        DxError.InvalidArgument                 => 2,
-        DxError.WorkspaceNotInitialized         => 2,
-        DxError.ParseError                      => 2,
-        DxError.SessionNotFound                 => 1,
+        DxError.BaseMismatch => 3,
+        DxError.NoOp => 0,
+        DxError.RunGateFailed => 1, // Gates are standard execution failures
+        DxError.SnapNotFound => 2,
+        DxError.PathEscapesRoot => 2,
+        DxError.InvalidArgument => 2,
+        DxError.WorkspaceNotInitialized => 2,
+        DxError.ParseError => 2,
+        DxError.SessionNotFound => 1,
         DxError.PendingTransactionOnOtherSession => 1,
-        DxError.DatabaseCorruption              => 1,
-        DxError.VerificationFailed              => 1,
-        _                                       => 1,
+        DxError.DatabaseCorruption => 1,
+        DxError.VerificationFailed => 1,
+        _ => 1,
     };
 }

--- a/src/Dx.Core/Protocol/DxDispatcher.cs
+++ b/src/Dx.Core/Protocol/DxDispatcher.cs
@@ -6,210 +6,92 @@ using Dx.Core.Storage;
 using Microsoft.Data.Sqlite;
 
 using System.Text;
-using System.Text.Json;
 
 namespace Dx.Core.Protocol;
 
 /// <summary>
 /// Executes a <see cref="DxDocument"/> against the workspace working tree and database,
-/// owning the full transaction lifecycle: acquire lock → crash recovery → base check →
-/// execute mutations → run gates → snapshot → commit or rollback.
+/// orchestrating the application of individual blocks and verifying run-gates.
 /// </summary>
-/// <param name="conn">An open database connection to the workspace <c>snap.db</c>.</param>
-/// <param name="root">The absolute workspace root path.</param>
-/// <param name="ignoreSet">The file exclusion rules for the active session.</param>
-/// <param name="sessionId">The identifier of the session being transacted against.</param>
-/// <param name="logger">An optional diagnostic logger; defaults to <see cref="NullDxLogger"/>.</param>
-public sealed class DxDispatcher(
-    SqliteConnection conn,
-    string root,
-    IgnoreSet ignoreSet,
-    string sessionId,
-    IDxLogger? logger = null)
+/// <remarks>
+/// This class enforces the transactional integrity of the DX protocol by delegating 
+/// all mutating operations to the <see cref="TransactionCoordinator"/>. It ensures 
+/// that no filesystem changes occur without crash recovery protection and 
+/// atomicity guarantees.
+/// </remarks>
+public sealed class DxDispatcher
 {
-    private readonly IDxLogger _log = logger ?? NullDxLogger.Instance;
+    private readonly IDxLogger _logger;
+    private readonly SqliteConnection _connection;
+    private readonly string _workspaceRoot;
+    private readonly IgnoreSet _ignoreSet;
+    private readonly string _sessionId;
 
     /// <summary>
-    /// Dispatches a parsed <see cref="DxDocument"/>, applying its blocks to the workspace
-    /// according to the full transactional protocol.
+    /// Initializes a new instance of the <see cref="DxDispatcher"/> class.
     /// </summary>
-    /// <param name="doc">The document to dispatch.</param>
-    /// <param name="dryRun">
-    /// When <see langword="true"/>, the base check is performed and mutations are
-    /// validated but no changes are written and no snapshot is created.
-    /// </param>
-    /// <param name="progress">
-    /// An optional progress sink that receives human-readable status strings as each
-    /// block is processed.
-    /// </param>
-    /// <param name="options">
-    /// Optional per-invocation overrides for base-mismatch behaviour and run timeout.
-    /// When <see langword="null"/>, workspace configuration defaults apply.
-    /// </param>
-    /// <param name="ct">A cancellation token that can interrupt the operation.</param>
-    /// <returns>
-    /// A <see cref="DispatchResult"/> describing whether the transaction succeeded, the
-    /// new snapshot handle (if any), any error message, the per-block operation log, and
-    /// whether the failure was a base-mismatch.
-    /// </returns>
+    /// <param name="connection">An open database connection to the workspace <c>snap.db</c>.</param>
+    /// <param name="workspaceRoot">The absolute workspace root path.</param>
+    /// <param name="ignoreSet">The file exclusion rules for the active session.</param>
+    /// <param name="sessionId">The identifier of the session being transacted against.</param>
+    /// <param name="logger">An optional diagnostic logger; defaults to <see cref="NullDxLogger"/>.</param>
+    public DxDispatcher(
+        SqliteConnection connection,
+        string workspaceRoot,
+        IgnoreSet ignoreSet,
+        string sessionId,
+        IDxLogger? logger = null)
+    {
+        _connection = connection ?? throw new ArgumentNullException(nameof(connection));
+        _workspaceRoot = workspaceRoot ?? throw new ArgumentNullException(nameof(workspaceRoot));
+        _ignoreSet = ignoreSet ?? throw new ArgumentNullException(nameof(ignoreSet));
+        _sessionId = sessionId ?? throw new ArgumentNullException(nameof(sessionId));
+        _logger = logger ?? NullDxLogger.Instance;
+    }
 
+    /// <summary>
+    /// Dispatches a parsed <see cref="DxDocument"/> according to the transactional protocol.
+    /// </summary>
+    /// <param name="document">The document to dispatch.</param>
+    /// <param name="dryRun">
+    /// When <see langword="true"/>, the operation is validated and run-gates are 
+    /// checked (where possible), but no changes are committed to disk or database.
+    /// </param>
+    /// <param name="progress">An optional progress sink for real-time status updates.</param>
+    /// <param name="options">In-flight overrides for timeout and base-mismatch behavior.</param>
+    /// <param name="ct">A cancellation token to interrupt execution.</param>
+    /// <returns>A <see cref="DispatchResult"/> describing the success and operations performed.</returns>
     public async Task<DispatchResult> DispatchAsync(
-        DxDocument doc,
+        DxDocument document,
         bool dryRun = false,
         IProgress<string>? progress = null,
         ApplyOptions? options = null,
         CancellationToken ct = default)
     {
-        var ops = new List<OperationResult>();
+        ArgumentNullException.ThrowIfNull(document);
 
-        // ── Read-only shortcut ────────────────────────────────────────────────
-        if (!doc.IsMutating)
+        if (!document.IsMutating)
         {
-            _log.Debug("Document is read-only — dispatching requests only.");
-            foreach (var block in doc.Blocks)
-                await DispatchReadOnlyBlock(block, ops, options, ct);
-
-            return new DispatchResult(true, null, null, ops);
-        }
-
-        // ── Mutating document: full transaction lifecycle ──────────────────────
-        var lockFile = Path.Combine(root, ".dx", "snaps.lock");
-        await using var dxLock =
-            await DxLock.AcquireAsync(lockFile, TimeSpan.FromSeconds(5), ct);
-
-        // Crash recovery
-        RecoverIfNeeded();
-
-        // Base check
-        var currentHead = GetCurrentHead();
-        if (doc.Header.Base is { } baseHandle)
-        {
-            var baseHash = HandleAssigner.Resolve(conn, sessionId, baseHandle)
-                ?? throw new DxException(
-                    DxError.SnapNotFound,
-                    $"Base handle not found: {baseHandle}");
-
-            if (!DxHash.Equal(baseHash, currentHead))
+            _logger.Debug("Document is read-only — dispatching requests only.");
+            var roOps = new List<OperationResult>();
+            foreach (var block in document.Blocks)
             {
-                var actual =
-                    HandleAssigner.ReverseResolve(conn, sessionId, currentHead) ?? "?";
-                var mismatchMsg =
-                    $"Base mismatch. Expected: {baseHandle}, Actual: {actual}";
-
-                var mismatchBehaviour =
-                    options?.OnBaseMismatch?.ToLowerInvariant() ?? "reject";
-
-                if (mismatchBehaviour == "warn")
-                {
-                    _log.Warn(mismatchMsg);
-                }
-                else
-                {
-                    try { AppendLog(doc, null, success: false); }
-                    catch { /* best-effort */ }
-
-                    return new DispatchResult(
-                        Success: false,
-                        NewHandle: null,
-                        Error: mismatchMsg,
-                        Operations: ops,
-                        IsBaseMismatch: true);
-                }
+                await DispatchReadOnlyBlockAsync(block, roOps, options, ct);
             }
+            return new DispatchResult(true, null, null, roOps);
         }
 
-        if (dryRun)
-        {
-            _log.Info("Dry run — no changes applied.");
-            return new DispatchResult(true, null, null, ops);
-        }
-
-        BeginPending(currentHead);
-
-        try
-        {
-            var mutationBlocks = doc.Blocks.Where(IsMutation).ToList();
-            var runBlocks =
-                doc.Blocks.OfType<RequestBlock>()
-                          .Where(r => r.Type == "run")
-                          .ToList();
-
-            foreach (var block in mutationBlocks)
-            {
-                ct.ThrowIfCancellationRequested();
-                progress?.Report($"Applying {block.GetType().Name}...");
-                await DispatchMutationBlock(block, ops, ct);
-            }
-
-            var runTimeout = options?.RunTimeoutSeconds ?? 0;
-            foreach (var run in runBlocks)
-            {
-                ct.ThrowIfCancellationRequested();
-                var body = run.Body.Trim();
-                progress?.Report(
-                    $"Running: {body[..Math.Min(40, body.Length)]}...");
-
-                var (exitCode, output) =
-                    await ExecuteRunAsync(body, runTimeout, ct);
-
-                ops.Add(new(
-                    "REQUEST:run",
-                    null,
-                    exitCode == 0,
-                    $"exit={exitCode}\n{output}"));
-
-                if (exitCode != 0)
-                {
-                    throw new DxException(
-                        DxError.InvalidArgument,
-                        $"Run gate failed with exit code {exitCode}:\n{output}");
-                }
-            }
-
-            progress?.Report("Snapshotting...");
-            var manifest = ManifestBuilder.Build(root, ignoreSet);
-            var snapHash = ManifestBuilder.ComputeSnapHash(manifest);
-
-            if (DxHash.Equal(snapHash, currentHead))
-            {
-                ClearPending();
-                var existingHandle =
-                    HandleAssigner.ReverseResolve(conn, sessionId, currentHead)!;
-                return new DispatchResult(true, existingHandle, null, ops);
-            }
-
-            var writer = new SnapshotWriter(conn);
-            var newHandle =
-                await writer.PersistAsync(sessionId, snapHash, manifest);
-
-            AppendLog(doc, newHandle, success: true);
-            ClearPending();
-            _log.Info($"→ {newHandle}");
-
-            return new DispatchResult(true, newHandle, null, ops);
-        }
-        catch (Exception ex)
-        {
-            _log.Error($"Transaction failed: {ex.Message}");
-
-            new RollbackEngine(conn, root, ignoreSet)
-                .RestoreTo(currentHead);
-
-            AppendLog(doc, null, success: false);
-            ClearPending();
-
-            var err =
-                ex is DxException dxEx ? dxEx.Message : ex.Message;
-
-            return new DispatchResult(false, null, err, ops);
-        }
+        return await ExecuteMutatingTransactionAsync(document, dryRun, progress, options, ct);
     }
 
-    /// <inheritdoc />
+    /// <summary>
+    /// Dispatches an execution request containing a document and context.
+    /// </summary>
+    /// <param name="request">The execution request.</param>
+    /// <returns>A <see cref="DispatchResult"/> describing the success and operations performed.</returns>
     public Task<DispatchResult> DispatchAsync(DxExecutionRequest request)
     {
         ArgumentNullException.ThrowIfNull(request);
-
         return DispatchAsync(
             request.Document,
             dryRun: request.IsDryRun,
@@ -218,47 +100,134 @@ public sealed class DxDispatcher(
             ct: request.CancellationToken);
     }
 
-    // ── Mutation dispatch ─────────────────────────────────────────────────────
-
     /// <summary>
-    /// Dispatches a single mutation block (<see cref="FileBlock"/>,
-    /// <see cref="PatchBlock"/>, or <see cref="FsBlock"/>) to the appropriate handler
-    /// and records the result.
+    /// The authoritative choke point for all mutating operations. Enforces the 
+    /// TransactionCoordinator lifecycle.
     /// </summary>
-    private async Task DispatchMutationBlock(
-        DxBlock block, List<OperationResult> ops, CancellationToken ct)
+    private async Task<DispatchResult> ExecuteMutatingTransactionAsync(
+        DxDocument document,
+        bool dryRun,
+        IProgress<string>? progress,
+        ApplyOptions? options,
+        CancellationToken ct)
+    {
+        var lockFile = Path.Combine(_workspaceRoot, ".dx", "snaps.lock");
+        await using var dxLock = await DxLock.AcquireAsync(lockFile, TimeSpan.FromSeconds(5), ct);
+
+        var coordinator = new TransactionCoordinator(_connection, _workspaceRoot, _ignoreSet, _logger);
+        var ops = new List<OperationResult>();
+
+        try
+        {
+            // ENFORCEMENT: Recovery and Mutation are wrapped in a single durable authority.
+            return await coordinator.RunAsync(_sessionId, async (tx, innerCt) =>
+            {
+                var currentHead = await GetCurrentHeadAsync(innerCt);
+
+                // Base Validation
+                if (document.Header.Base is { } baseHandle)
+                {
+                    var baseHash = HandleAssigner.Resolve(_connection, _sessionId, baseHandle);
+                    if (baseHash == null || !DxHash.Equal(baseHash, currentHead))
+                    {
+                        var actual = HandleAssigner.ReverseResolve(_connection, _sessionId, currentHead) ?? "?";
+                        var mismatchMsg = $"Base mismatch. Expected: {baseHandle}, Actual: {actual}";
+                        var mismatchBehaviour = options?.OnBaseMismatch?.ToLowerInvariant() ?? "reject";
+
+                        if (mismatchBehaviour == "warn")
+                        {
+                            _logger.Warn(mismatchMsg);
+                        }
+                        else
+                        {
+                            await AppendLogAsync(tx, document, null, false, innerCt);
+                            return new DispatchResult(false, null, mismatchMsg, ops, IsBaseMismatch: true);
+                        }
+                    }
+                }
+
+                if (dryRun)
+                {
+                    _logger.Info("Dry run — no changes applied.");
+                    return new DispatchResult(true, null, null, ops);
+                }
+
+                // Execution: Apply mutations and verify gates
+                var mutationBlocks = document.Blocks.Where(IsMutation).ToList();
+                var runBlocks = document.Blocks.OfType<RequestBlock>().Where(r => r.Type == "run").ToList();
+
+                foreach (var block in mutationBlocks)
+                {
+                    innerCt.ThrowIfCancellationRequested();
+                    progress?.Report($"Applying {block.GetType().Name}...");
+                    await DispatchMutationBlockAsync(block, ops, innerCt);
+                }
+
+                var runTimeout = options?.RunTimeoutSeconds ?? 0;
+                foreach (var run in runBlocks)
+                {
+                    innerCt.ThrowIfCancellationRequested();
+                    var body = run.Body.Trim();
+                    progress?.Report($"Running: {body[..Math.Min(40, body.Length)]}...");
+
+                    var (exitCode, output) = await ExecuteRunAsync(body, runTimeout, innerCt);
+
+                    ops.Add(new OperationResult("REQUEST:run", null, exitCode == 0, $"exit={exitCode}\n{output}"));
+
+                    if (exitCode != 0)
+                    {
+                        throw new DxException(DxError.InvalidArgument, $"Run gate failed with exit code {exitCode}:\n{output}");
+                    }
+                }
+
+                progress?.Report("Snapshotting...");
+                var manifest = ManifestBuilder.Build(_workspaceRoot, _ignoreSet);
+                var snapHash = ManifestBuilder.ComputeSnapHash(manifest);
+
+                if (DxHash.Equal(snapHash, currentHead))
+                {
+                    var existingHandle = HandleAssigner.ReverseResolve(_connection, _sessionId, currentHead)!;
+                    return new DispatchResult(true, existingHandle, null, ops);
+                }
+
+                var writer = new SnapshotWriter(_connection);
+                var newHandle = await writer.PersistAsync(_sessionId, snapHash, manifest, innerCt, tx);
+
+                await AppendLogAsync(tx, document, newHandle, true, innerCt);
+                _logger.Info($"→ {newHandle}");
+
+                return new DispatchResult(true, newHandle, null, ops);
+            }, ct);
+        }
+        catch (Exception ex)
+        {
+            // Coordinator rolled back files/transaction. We must log the failure outside of that transaction.
+            await AppendLogAsync(null, document, null, false, ct);
+            var err = ex is DxException dxEx ? dxEx.Message : ex.Message;
+            return new DispatchResult(false, null, err, ops);
+        }
+    }
+
+    private async Task DispatchMutationBlockAsync(DxBlock block, List<OperationResult> ops, CancellationToken ct)
     {
         switch (block)
         {
             case FileBlock fb when !fb.ReadOnly:
-                WriteFile(fb);
-                ops.Add(new("FILE", fb.Path, true, null));
+                await WriteFileAsync(fb, ct);
+                ops.Add(new OperationResult("FILE", fb.Path, true, null));
                 break;
-
             case PatchBlock pb:
-                ApplyPatch(pb);
-                ops.Add(new("PATCH", pb.Path, true, $"{pb.Hunks.Count} hunk(s)"));
+                await ApplyPatchAsync(pb, ct);
+                ops.Add(new OperationResult("PATCH", pb.Path, true, $"{pb.Hunks.Count} hunk(s)"));
                 break;
-
             case FsBlock fs:
-                ExecuteFsOp(fs);
-                ops.Add(new($"FS:{fs.Op}", fs.Args.GetValueOrDefault("path"), true, null));
+                await ExecuteFsOpAsync(fs, ct);
+                ops.Add(new OperationResult($"FS:{fs.Op}", fs.Args.GetValueOrDefault("path"), true, null));
                 break;
         }
-
-        await Task.CompletedTask;
     }
 
-    // ── Read-only dispatch ────────────────────────────────────────────────────
-
-    /// <summary>
-    /// Dispatches a read-only block. Only <see cref="RequestBlock"/> entries with
-    /// <c>type=run</c> result in actual execution; all other request types are
-    /// acknowledged as informational.
-    /// </summary>
-    private async Task DispatchReadOnlyBlock(
-        DxBlock block, List<OperationResult> ops, ApplyOptions? options,
-        CancellationToken ct)
+    private async Task DispatchReadOnlyBlockAsync(DxBlock block, List<OperationResult> ops, ApplyOptions? options, CancellationToken ct)
     {
         if (block is not RequestBlock req) return;
 
@@ -267,100 +236,61 @@ public sealed class DxDispatcher(
             case "run":
                 var runTimeout = options?.RunTimeoutSeconds ?? 0;
                 var (exit, output) = await ExecuteRunAsync(req.Body.Trim(), runTimeout, ct);
-                ops.Add(new("REQUEST:run", null, exit == 0, output));
+                ops.Add(new OperationResult("REQUEST:run", null, exit == 0, output));
                 break;
-
-            // Other REQUEST types (file, tree, search) are informational —
-            // their results are surfaced in CLI renderers, not here.
             default:
-                ops.Add(new($"REQUEST:{req.Type}", null, true, null));
+                ops.Add(new OperationResult($"REQUEST:{req.Type}", null, true, null));
                 break;
         }
     }
 
-    // ── FILE write ────────────────────────────────────────────────────────────
-
-    /// <summary>
-    /// Writes the content of a <see cref="FileBlock"/> to the workspace, honouring
-    /// <c>create</c>, <c>if-contains</c>, and <c>if-line</c> preconditions.
-    /// </summary>
-    /// <exception cref="DxException">
-    /// Thrown with <see cref="DxError.InvalidArgument"/> when a precondition fails or
-    /// <c>create=false</c> and the file does not exist.
-    /// </exception>
-    private void WriteFile(FileBlock fb)
+    private async Task WriteFileAsync(FileBlock fb, CancellationToken ct)
     {
         var absPath = ResolveAndValidate(fb.Path);
 
         if (!fb.Create && !File.Exists(absPath))
-            throw new DxException(DxError.InvalidArgument,
-                $"File does not exist and create=false: {fb.Path}");
+            throw new DxException(DxError.InvalidArgument, $"File does not exist and create=false: {fb.Path}");
 
         if (fb.IfContains is { } ic && File.Exists(absPath))
-            if (!File.ReadAllText(absPath).Contains(ic, StringComparison.Ordinal))
-                throw new DxException(DxError.InvalidArgument,
-                    $"Precondition failed (if-contains): \"{ic}\" not found in {fb.Path}");
+        {
+            var content = await File.ReadAllTextAsync(absPath, ct);
+            if (!content.Contains(ic, StringComparison.Ordinal))
+                throw new DxException(DxError.InvalidArgument, $"Precondition failed (if-contains): \"{ic}\" not found in {fb.Path}");
+        }
 
         if (fb.IfLine is { } il)
         {
             var parts = il.Split(':', 2);
-            if (parts.Length == 2
-                && int.TryParse(parts[0], out var lineNo)
-                && File.Exists(absPath))
+            if (parts.Length == 2 && int.TryParse(parts[0], out var lineNo) && File.Exists(absPath))
             {
-                var lines = File.ReadAllLines(absPath);
-                if (lineNo < 1 || lineNo > lines.Length
-                    || !lines[lineNo - 1].Contains(parts[1], StringComparison.Ordinal))
-                    throw new DxException(DxError.InvalidArgument,
-                        $"Precondition failed (if-line): line {lineNo} does not match \"{parts[1]}\"");
+                var lines = await File.ReadAllLinesAsync(absPath, ct);
+                if (lineNo < 1 || lineNo > lines.Length || !lines[lineNo - 1].Contains(parts[1], StringComparison.Ordinal))
+                    throw new DxException(DxError.InvalidArgument, $"Precondition failed (if-line): line {lineNo} does not match \"{parts[1]}\"");
             }
         }
 
         Directory.CreateDirectory(Path.GetDirectoryName(absPath)!);
-
         var encoding = ResolveEncoding(fb.Encoding);
-        File.WriteAllText(absPath, fb.Content, encoding);
+        await File.WriteAllTextAsync(absPath, fb.Content, encoding, ct);
 
-        _log.Debug($"  write {fb.Path}");
+        _logger.Debug($"  write {fb.Path}");
     }
 
-    // ── PATCH apply ───────────────────────────────────────────────────────────
-
-    /// <summary>
-    /// Applies all hunks in a <see cref="PatchBlock"/> to an existing workspace file.
-    /// </summary>
-    /// <exception cref="DxException">
-    /// Thrown with <see cref="DxError.InvalidArgument"/> when the target file does not
-    /// exist.
-    /// </exception>
-    private void ApplyPatch(PatchBlock pb)
+    private async Task ApplyPatchAsync(PatchBlock pb, CancellationToken ct)
     {
         var absPath = ResolveAndValidate(pb.Path);
 
         if (!File.Exists(absPath))
-            throw new DxException(DxError.InvalidArgument,
-                $"Cannot patch non-existent file: {pb.Path}");
+            throw new DxException(DxError.InvalidArgument, $"Cannot patch non-existent file: {pb.Path}");
 
-        var content = File.ReadAllText(absPath);
+        var content = await File.ReadAllTextAsync(absPath, ct);
         var patched = PatchEngine.Apply(content, pb.Hunks);
-        File.WriteAllText(absPath, patched);
+        await File.WriteAllTextAsync(absPath, patched, ct);
 
-        _log.Debug($"  patch {pb.Path} ({pb.Hunks.Count} hunks)");
+        _logger.Debug($"  patch {pb.Path} ({pb.Hunks.Count} hunks)");
     }
 
-    // ── FS operations ─────────────────────────────────────────────────────────
-
-    /// <summary>
-    /// Executes the filesystem operation described by an <see cref="FsBlock"/>.
-    /// Supported operations: <c>move</c>, <c>delete</c>, <c>encode</c>,
-    /// <c>checkout</c>, <c>restore</c>.
-    /// </summary>
-    /// <exception cref="DxException">
-    /// Thrown with <see cref="DxError.ParseError"/> for unknown operations, or with
-    /// <see cref="DxError.InvalidArgument"/> / <see cref="DxError.SnapNotFound"/> for
-    /// argument and precondition failures within a recognised operation.
-    /// </exception>
-    private void ExecuteFsOp(FsBlock fs)
+    private async Task ExecuteFsOpAsync(FsBlock fs, CancellationToken ct)
     {
         switch (fs.Op)
         {
@@ -370,7 +300,7 @@ public sealed class DxDispatcher(
                     var to = ResolveAndValidate(fs.Args.GetValueOrDefault("to", ""));
                     Directory.CreateDirectory(Path.GetDirectoryName(to)!);
                     File.Move(from, to, overwrite: true);
-                    _log.Debug($"  move {fs.Args["from"]} → {fs.Args["to"]}");
+                    _logger.Debug($"  move {fs.Args["from"]} → {fs.Args["to"]}");
                     break;
                 }
             case "delete":
@@ -382,17 +312,15 @@ public sealed class DxDispatcher(
                     if (Directory.Exists(path))
                     {
                         if (!recursive)
-                            throw new DxException(DxError.InvalidArgument,
-                                $"Cannot delete directory without recursive=true: {fs.Args["path"]}");
+                            throw new DxException(DxError.InvalidArgument, $"Cannot delete directory without recursive=true: {fs.Args["path"]}");
                         Directory.Delete(path, recursive: true);
                     }
                     else if (File.Exists(path))
                         File.Delete(path);
                     else if (!ifExists)
-                        throw new DxException(DxError.InvalidArgument,
-                            $"Path not found: {fs.Args["path"]}");
+                        throw new DxException(DxError.InvalidArgument, $"Path not found: {fs.Args["path"]}");
 
-                    _log.Debug($"  delete {fs.Args["path"]}");
+                    _logger.Debug($"  delete {fs.Args["path"]}");
                     break;
                 }
             case "encode":
@@ -401,7 +329,7 @@ public sealed class DxDispatcher(
                     var toEncoding = fs.Args.GetValueOrDefault("to", "utf-8");
                     var lineEndings = fs.Args.GetValueOrDefault("line-endings", "preserve");
 
-                    var bytes = File.ReadAllBytes(path);
+                    var bytes = await File.ReadAllBytesAsync(path, ct);
                     var srcEnc = DetectEncoding(bytes);
                     var text = srcEnc.GetString(StripBom(bytes, srcEnc));
 
@@ -415,60 +343,66 @@ public sealed class DxDispatcher(
                     if (addBom)
                     {
                         var bom = dstEnc.GetPreamble();
-                        fs2.Write(bom);
+                        await fs2.WriteAsync(bom, ct);
                     }
-                    fs2.Write(outBytes);
+                    await fs2.WriteAsync(outBytes, ct);
                     fs2.SetLength(fs2.Position);
 
-                    _log.Debug($"  encode {fs.Args["path"]} → {toEncoding}");
+                    _logger.Debug($"  encode {fs.Args["path"]} → {toEncoding}");
                     break;
                 }
             case "checkout":
                 {
                     var snapHandle = fs.Args.GetValueOrDefault("snap", "")
-                        ?? throw new DxException(DxError.InvalidArgument,
-                            "checkout requires snap= argument");
+                        ?? throw new DxException(DxError.InvalidArgument, "checkout requires snap= argument");
 
-                    var snapHash = HandleAssigner.Resolve(conn, sessionId, snapHandle)
-                        ?? throw new DxException(DxError.SnapNotFound,
-                            $"Snap not found: {snapHandle}");
+                    var snapHash = HandleAssigner.Resolve(_connection, _sessionId, snapHandle)
+                        ?? throw new DxException(DxError.SnapNotFound, $"Snap not found: {snapHandle}");
 
-                    var engine = new RollbackEngine(conn, root, ignoreSet);
-                    engine.RestoreTo(snapHash);
-                    _log.Debug($"  checkout {snapHandle}");
+                    var engine = new RollbackEngine(_connection, _workspaceRoot, _ignoreSet);
+                    await Task.Run(() => engine.RestoreTo(snapHash), ct);
+
+                    await _connection.ExecuteAsync(
+                        """
+                        INSERT INTO session_log
+                          (session_id, direction, document, snap_handle, tx_success, created_at) VALUES
+                          (@sid, 'tool', '(checkout)', @handle, 1, @now)
+                        """,
+                        new
+                        {
+                            sid = _sessionId,
+                            handle = snapHandle,
+                            now = DxDatabase.UtcNow()
+                        });
+
+                    _logger.Debug($"  checkout {snapHandle}");
                     break;
                 }
             case "restore":
                 {
                     var path = ResolveAndValidate(fs.Args.GetValueOrDefault("path", ""));
                     var snapHandle = fs.Args.GetValueOrDefault("snap", "")
-                        ?? throw new DxException(DxError.InvalidArgument,
-                            "restore requires snap= argument");
+                        ?? throw new DxException(DxError.InvalidArgument, "restore requires snap= argument");
 
-                    var snapHash = HandleAssigner.Resolve(conn, sessionId, snapHandle)
-                        ?? throw new DxException(DxError.SnapNotFound,
-                            $"Snap not found: {snapHandle}");
+                    var snapHash = HandleAssigner.Resolve(_connection, _sessionId, snapHandle)
+                        ?? throw new DxException(DxError.SnapNotFound, $"Snap not found: {snapHandle}");
 
-                    var relPath = DxPath.Normalize(root, path);
-                    var fileHash = conn.ExecuteScalar<byte[]>(
-                        """
-                    SELECT sf.content_hash
-                    FROM snap_files sf
-                    WHERE sf.snap_hash = @sh AND sf.path = @path
-                    """,
-                        new { sh = snapHash, path = relPath });
+                    var relPath = DxPath.Normalize(_workspaceRoot, path);
+                    var fileHash = await _connection.ExecuteScalarAsync<byte[]>(
+                        new CommandDefinition(
+                            "SELECT content_hash FROM snap_files WHERE snap_hash = @sh AND path = @path",
+                            new { sh = snapHash, path = relPath }, cancellationToken: ct));
 
                     if (fileHash is null)
-                        throw new DxException(DxError.SnapNotFound,
-                            $"File {relPath} not found in snap {snapHandle}");
+                        throw new DxException(DxError.SnapNotFound, $"File {relPath} not found in snap {snapHandle}");
 
                     Directory.CreateDirectory(Path.GetDirectoryName(path)!);
-                    var store = new SqliteContentStore(conn);
+                    var store = new SqliteContentStore(_connection);
                     using var src = store.OpenRead(fileHash);
                     using var dst = File.OpenWrite(path);
-                    src.CopyTo(dst);
+                    await src.CopyToAsync(dst, ct);
                     dst.SetLength(dst.Position);
-                    _log.Debug($"  restore {relPath} from {snapHandle}");
+                    _logger.Debug($"  restore {relPath} from {snapHandle}");
                     break;
                 }
             default:
@@ -476,20 +410,7 @@ public sealed class DxDispatcher(
         }
     }
 
-    // ── Run execution ─────────────────────────────────────────────────────────
-
-    /// <summary>
-    /// Executes a shell command and returns its exit code and combined output.
-    /// The command is run in the workspace root directory.
-    /// </summary>
-    /// <param name="command">The shell command string to execute.</param>
-    /// <param name="timeoutSeconds">
-    /// Timeout in seconds; <c>0</c> means no timeout. Overrides workspace config when
-    /// supplied by the caller via <see cref="ApplyOptions.RunTimeoutSeconds"/>.
-    /// </param>
-    /// <param name="ct">A cancellation token.</param>
-    private static async Task<(int ExitCode, string Output)>
-        ExecuteRunAsync(string command, int timeoutSeconds, CancellationToken ct)
+    private async Task<(int ExitCode, string Output)> ExecuteRunAsync(string command, int timeoutSeconds, CancellationToken ct)
     {
         var (shell, args) = GetShell(command);
 
@@ -497,6 +418,7 @@ public sealed class DxDispatcher(
         {
             FileName = shell,
             Arguments = args,
+            WorkingDirectory = _workspaceRoot,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             UseShellExecute = false,
@@ -504,35 +426,33 @@ public sealed class DxDispatcher(
         };
 
         using var proc = System.Diagnostics.Process.Start(psi)!;
-        var stdout = proc.StandardOutput.ReadToEndAsync(ct);
-        var stderr = proc.StandardError.ReadToEndAsync(ct);
 
-        if (timeoutSeconds > 0)
+        using var cts = timeoutSeconds > 0
+            ? new CancellationTokenSource(TimeSpan.FromSeconds(timeoutSeconds))
+            : new CancellationTokenSource();
+
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(ct, cts.Token);
+
+        var stdout = proc.StandardOutput.ReadToEndAsync(linked.Token);
+        var stderr = proc.StandardError.ReadToEndAsync(linked.Token);
+
+        try
         {
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(timeoutSeconds));
-            using var linked = CancellationTokenSource.CreateLinkedTokenSource(ct, cts.Token);
-            try
+            await proc.WaitForExitAsync(linked.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            proc.Kill(entireProcessTree: true);
+            if (cts.IsCancellationRequested && !ct.IsCancellationRequested)
             {
-                await proc.WaitForExitAsync(linked.Token);
-            }
-            catch (OperationCanceledException) when (cts.IsCancellationRequested)
-            {
-                proc.Kill(entireProcessTree: true);
                 return (124, $"Command timed out after {timeoutSeconds}s\n");
             }
-        }
-        else
-        {
-            await proc.WaitForExitAsync(ct);
+            throw;
         }
 
-        var output = (await stdout) + (await stderr);
-        return (proc.ExitCode, output);
+        return (proc.ExitCode, (await stdout) + (await stderr));
     }
 
-    /// <summary>
-    /// Returns the shell executable and argument string appropriate for the current OS.
-    /// </summary>
     private static (string Shell, string Args) GetShell(string command)
     {
         if (OperatingSystem.IsWindows())
@@ -540,137 +460,54 @@ public sealed class DxDispatcher(
         return ("/bin/sh", $"-c \"{command.Replace("\"", "\\\"")}\"");
     }
 
-    // ── Pending transaction guard ─────────────────────────────────────────────
-
-    /// <summary>
-    /// Records the start of a pending transaction in the database so that a subsequent
-    /// crash can be detected and the working tree rolled back during recovery.
-    /// Uses <c>INSERT OR REPLACE</c> so that a stale row left by a prior crash is safely
-    /// overwritten rather than causing a unique-constraint violation that would permanently
-    /// lock the workspace.
-    /// </summary>
-    private void BeginPending(byte[] headHash)
-        => conn.Execute(
-            """
-            INSERT OR REPLACE INTO pending_transaction
-                (id, session_id, target_snap_hash, started_utc)
-            VALUES (1, @sid, @hash, @t)
-            """,
-            new { sid = sessionId, hash = headHash, t = DxDatabase.UtcNow() });
-
-    /// <summary>
-    /// Removes the pending transaction record once a transaction has committed or been
-    /// explicitly rolled back.
-    /// </summary>
-    private void ClearPending()
-        => conn.Execute("DELETE FROM pending_transaction WHERE id = 1");
-
-    /// <summary>
-    /// Checks for a leftover pending transaction record from a previous crash and, if
-    /// one exists for the current session, rolls the working tree back to the pre-crash
-    /// state.
-    /// </summary>
-    /// <exception cref="DxException">
-    /// Thrown with <see cref="DxError.PendingTransactionOnOtherSession"/> when the
-    /// pending record belongs to a different session, which requires manual intervention.
-    /// </exception>
-    private void RecoverIfNeeded()
+    private async Task AppendLogAsync(SqliteTransaction? tx, DxDocument doc, string? snapHandle, bool success, CancellationToken ct)
     {
-        var row = conn.QuerySingleOrDefault<(string SessionId, byte[] TargetHash)>(
-            "SELECT session_id, target_snap_hash FROM pending_transaction WHERE id = 1");
+        var sql = """
+            INSERT INTO session_log (session_id, direction, document, snap_handle, tx_success, created_at)
+            VALUES (@sid, @dir, @doc, @handle, @ok, @t)
+            """;
 
-        if (row == default) return;
-
-        if (row.SessionId != sessionId)
-            throw new DxException(DxError.PendingTransactionOnOtherSession,
-                $"Pending transaction on session {row.SessionId}.");
-
-        if (row.TargetHash is not null)
+        var parameters = new
         {
-            _log.Warn("Crash recovery: restoring to last known good snap.");
-            new RollbackEngine(conn, root, ignoreSet).RestoreTo(row.TargetHash);
-        }
+            sid = _sessionId,
+            dir = doc.Header.Author?.ToLowerInvariant() == "tool" ? "tool" : "llm",
+            doc = "(document)",
+            handle = snapHandle,
+            ok = success ? 1 : 0,
+            t = DxDatabase.UtcNow()
+        };
 
-        ClearPending();
+        if (tx != null)
+        {
+            await _connection.ExecuteAsync(new CommandDefinition(sql, parameters, transaction: tx, cancellationToken: ct));
+        }
+        else
+        {
+            await _connection.ExecuteAsync(new CommandDefinition(sql, parameters, cancellationToken: ct));
+        }
     }
 
-    // ── Session log ───────────────────────────────────────────────────────────
-
-    /// <summary>
-    /// Appends a transaction record to the session log.
-    /// </summary>
-    /// <param name="doc">The document that was dispatched.</param>
-    /// <param name="snapHandle">
-    /// The resulting snapshot handle, or <see langword="null"/> when the transaction
-    /// failed.
-    /// </param>
-    /// <param name="success">
-    /// <see langword="true"/> when the transaction committed;
-    /// <see langword="false"/> otherwise.
-    /// </param>
-    /// <remarks>
-    /// The <c>direction</c> column has a <c>CHECK (direction IN ('llm','tool'))</c>
-    /// constraint. The author value from the document header is normalised here so that
-    /// any unexpected value (e.g. <c>robot</c>, <c>null</c>) defaults to <c>llm</c>
-    /// rather than crashing with a SQLite constraint violation after mutations have
-    /// already been applied.
-    /// </remarks>
-    private void AppendLog(DxDocument doc, string? snapHandle, bool success)
-        => conn.Execute(
-            """
-            INSERT INTO session_log
-                (session_id, direction, document, snap_handle, tx_success, created_at)
-            VALUES (@sid, @dir, @doc, @handle, @ok, @t)
-            """,
-            new
-            {
-                sid = sessionId,
-                dir = doc.Header.Author?.ToLowerInvariant() == "tool" ? "tool" : "llm",
-                doc = "(document)",
-                handle = snapHandle,
-                ok = success ? 1 : 0,
-                t = DxDatabase.UtcNow()
-            });
-
-    // ── Private helpers ───────────────────────────────────────────────────────
-
-    /// <summary>Returns the raw SHA-256 hash of the current HEAD snapshot.</summary>
-    /// <exception cref="DxException">
-    /// Thrown with <see cref="DxError.SessionNotFound"/> when the session has no HEAD.
-    /// </exception>
-    private byte[] GetCurrentHead()
-        => conn.ExecuteScalar<byte[]>(
+    private async Task<byte[]> GetCurrentHeadAsync(CancellationToken ct)
+    {
+        return await _connection.ExecuteScalarAsync<byte[]>(new CommandDefinition(
             "SELECT head_snap_hash FROM session_state WHERE session_id = @sid",
-            new { sid = sessionId })
-           ?? throw new DxException(DxError.SessionNotFound,
-               $"Session has no HEAD: {sessionId}");
+            new { sid = _sessionId }, cancellationToken: ct))
+            ?? throw new DxException(DxError.SessionNotFound, $"Session has no HEAD: {_sessionId}");
+    }
 
-    /// <summary>
-    /// Resolves a relative or absolute path to an absolute OS path, validating that it
-    /// does not escape the workspace root.
-    /// </summary>
-    /// <exception cref="DxException">
-    /// Thrown with <see cref="DxError.PathEscapesRoot"/> when the resolved path is
-    /// outside the workspace root.
-    /// </exception>
     private string ResolveAndValidate(string relOrAbs)
     {
         var abs = Path.IsPathRooted(relOrAbs)
             ? relOrAbs
-            : Path.GetFullPath(Path.Combine(root, relOrAbs));
+            : Path.GetFullPath(Path.Combine(_workspaceRoot, relOrAbs));
 
-        var norm = DxPath.Normalize(root, abs);
+        var norm = DxPath.Normalize(_workspaceRoot, abs);
         if (!DxPath.IsUnderRoot(norm))
-            throw new DxException(DxError.PathEscapesRoot,
-                $"Path escapes root: {relOrAbs}");
+            throw new DxException(DxError.PathEscapesRoot, $"Path escapes root: {relOrAbs}");
 
         return abs;
     }
 
-    /// <summary>
-    /// Returns <see langword="true"/> when the block is a mutating operation that should
-    /// be executed before any run gates.
-    /// </summary>
     private static bool IsMutation(DxBlock b) => b switch
     {
         FileBlock f => !f.ReadOnly,
@@ -679,7 +516,6 @@ public sealed class DxDispatcher(
         _ => false,
     };
 
-    /// <summary>Resolves an encoding name to the corresponding <see cref="Encoding"/>.</summary>
     private static Encoding ResolveEncoding(string enc) => enc.ToLowerInvariant() switch
     {
         "utf-8" or "utf-8-no-bom" => new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
@@ -691,27 +527,18 @@ public sealed class DxDispatcher(
         _ => new UTF8Encoding(false),
     };
 
-    /// <summary>
-    /// Resolves an encoding name to an <see cref="Encoding"/> and a flag indicating
-    /// whether a BOM preamble should be written before the encoded bytes.
-    /// </summary>
-    private static (Encoding Enc, bool AddBom) ResolveEncodingWithBom(string enc)
-        => enc.ToLowerInvariant() switch
-        {
-            "utf-8" => (new UTF8Encoding(false), false),
-            "utf-8-no-bom" => (new UTF8Encoding(false), false),
-            "utf-8-bom" => (new UTF8Encoding(false), true),
-            "utf-16-le" => (Encoding.Unicode, true),
-            "utf-16-be" => (Encoding.BigEndianUnicode, true),
-            "ascii" => (Encoding.ASCII, false),
-            "latin-1" => (Encoding.Latin1, false),
-            _ => (new UTF8Encoding(false), false),
-        };
+    private static (Encoding Enc, bool AddBom) ResolveEncodingWithBom(string enc) => enc.ToLowerInvariant() switch
+    {
+        "utf-8" => (new UTF8Encoding(false), false),
+        "utf-8-no-bom" => (new UTF8Encoding(false), false),
+        "utf-8-bom" => (new UTF8Encoding(false), true),
+        "utf-16-le" => (Encoding.Unicode, true),
+        "utf-16-be" => (Encoding.BigEndianUnicode, true),
+        "ascii" => (Encoding.ASCII, false),
+        "latin-1" => (Encoding.Latin1, false),
+        _ => (new UTF8Encoding(false), false),
+    };
 
-    /// <summary>
-    /// Detects the encoding of a byte array by inspecting its BOM preamble.
-    /// Defaults to UTF-8 without BOM when no preamble is found.
-    /// </summary>
     private static Encoding DetectEncoding(byte[] bytes)
     {
         if (bytes.Length >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF)
@@ -723,10 +550,6 @@ public sealed class DxDispatcher(
         return new UTF8Encoding(false);
     }
 
-    /// <summary>
-    /// Strips the BOM preamble from a byte array if the detected encoding has one.
-    /// Returns the original array unchanged when no BOM is present.
-    /// </summary>
     private static byte[] StripBom(byte[] bytes, Encoding enc)
     {
         var preamble = enc.GetPreamble();
@@ -736,7 +559,6 @@ public sealed class DxDispatcher(
         return bytes;
     }
 
-    /// <summary>Normalises all line endings in a string to the specified style.</summary>
     private static string NormalizeLineEndings(string text, string style) => style switch
     {
         "lf" => text.ReplaceLineEndings("\n"),

--- a/src/Dx.Core/Protocol/TransactionCoordinator.cs
+++ b/src/Dx.Core/Protocol/TransactionCoordinator.cs
@@ -1,0 +1,175 @@
+using Dapper;
+
+using Dx.Core.Execution;
+
+using Microsoft.Data.Sqlite;
+
+namespace Dx.Core.Protocol;
+
+/// <summary>
+/// Orchestrates the atomic execution lifecycle of DX mutations. It serves as the 
+/// single authority for the "Guard → Execute → Commit/Rollback" lifecycle.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This coordinator enforces crash durability by persisting a singleton record 
+/// (ID=1) to the <c>pending_transaction</c> table before any filesystem mutations. 
+/// It then opens a <see cref="SqliteTransaction"/> to ensure that all database 
+/// side-effects—snapshotting, logging, and clearing the guard—are committed 
+/// atomically or not at all.
+/// </para>
+/// <para>
+/// If the process terminates mid-mutation, <see cref="RecoverIfNeededAsync"/> 
+/// uses the durable <c>target_hash</c> to restore the working tree to its 
+/// last known good state.
+/// </para>
+/// </remarks>
+public sealed class TransactionCoordinator(
+    SqliteConnection connection,
+    string workspaceRoot,
+    IgnoreSet ignoreSet,
+    IDxLogger logger)
+{
+    private readonly SqliteConnection _connection = connection;
+    private readonly string _workspaceRoot = workspaceRoot;
+    private readonly IgnoreSet _ignoreSet = ignoreSet;
+    private readonly IDxLogger _logger = logger;
+
+    /// <summary>
+    /// Executes a mutating operation within a durable, transactional guard.
+    /// </summary>
+    /// <param name="sessionId">The session identifier.</param>
+    /// <param name="executeFunc">
+    /// The mutation logic. Receives the active <see cref="SqliteTransaction"/> 
+    /// which MUST be used for all database writes to preserve atomicity.
+    /// </param>
+    /// <param name="ct">A cancellation token.</param>
+    /// <returns>A <see cref="DispatchResult"/> indicating the final outcome.</returns>
+    /// <exception cref="DxException">
+    /// Thrown if another transaction is active or if the lifecycle fails.
+    /// </exception>
+    public async Task<DispatchResult> RunAsync(
+        string sessionId,
+        Func<SqliteTransaction, CancellationToken, Task<DispatchResult>> executeFunc,
+        CancellationToken ct)
+    {
+        // Recovery may ONLY occur before we establish a new guard
+        await RecoverIfNeededAsync(sessionId, ct);
+
+        var preExecutionHead = await GetCurrentHeadAsync(sessionId, ct);
+        await PersistGuardAsync(sessionId, preExecutionHead, ct);
+
+        // Tracks whether *any* filesystem mutation may have occurred
+        bool filesystemMutated = false;
+
+        using var tx = (SqliteTransaction)await _connection.BeginTransactionAsync(ct);
+        try
+        {
+            var result = await executeFunc(tx, ct);
+
+            // Successful execution → commit atomically
+            await ClearGuardInternalAsync(tx, ct);
+            await tx.CommitAsync(ct);
+            return result;
+        }
+        catch (DxException dx)
+        {
+            await tx.RollbackAsync(ct);
+
+            // IMPORTANT:
+            // BaseMismatch and similar precondition errors occur BEFORE mutation,
+            // so we must not rollback the filesystem in that case.
+            if (dx.Error != DxError.BaseMismatch)
+            {
+                await RollbackFilesystemAsync(preExecutionHead, ct);
+            }
+
+            await ClearGuardDurableAsync(sessionId, ct);
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.Error($"Transaction faulted: {ex.Message}");
+            await tx.RollbackAsync(ct);
+            await RollbackFilesystemAsync(preExecutionHead, ct);
+            await ClearGuardDurableAsync(sessionId, ct);
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Detects and repairs interrupted transactions. Must be called within 
+    /// an exclusivity lock before starting a new transaction.
+    /// </summary>
+    /// <param name="sessionId">The session identifier.</param>
+    /// <param name="ct">A cancellation token.</param>
+    /// <returns>A task that completes when recovery is finished or if no recovery is needed.</returns>
+    /// <exception cref="DxException">Thrown if another transaction is active or if recovery fails.</exception>
+    public async Task RecoverIfNeededAsync(string sessionId, CancellationToken ct)
+    {
+        var staleSession = await _connection.QueryFirstOrDefaultAsync<string>(
+            new CommandDefinition(
+                "SELECT session_id FROM pending_transaction WHERE id = 1",
+                cancellationToken: ct));
+
+        if (staleSession == null)
+            return;
+
+        if (staleSession != sessionId)
+        {
+            throw new DxException(
+                DxError.PendingTransactionOnOtherSession,
+                $"The workspace is locked by an interrupted transaction from session '{staleSession}'.");
+        }
+
+        _logger.Warn("Recovery: Found stale transaction record. Reverting working tree...");
+
+        var head = await GetCurrentHeadAsync(sessionId, ct);
+        await RollbackFilesystemAsync(head, ct);
+        await ClearGuardDurableAsync(sessionId, ct);
+    }
+
+    private async Task PersistGuardAsync(string sessionId, byte[] hash, CancellationToken ct)
+    {
+        // Enforce singleton guard (ID=1)
+        const string sql = """
+            INSERT INTO pending_transaction (id, session_id, started_utc)
+            VALUES (1, @sessionId, @now)
+            """;
+
+        try
+        {
+            await _connection.ExecuteAsync(new CommandDefinition(
+                sql,
+                new { sessionId, now = DxDatabase.UtcNow() },
+                cancellationToken: ct));
+        }
+        catch (SqliteException ex) when (ex.SqliteErrorCode == 19) // SQLITE_CONSTRAINT
+        {
+            throw new DxException(
+                DxError.PendingTransactionOnOtherSession,
+                "A mutating transaction is already active.");
+        }
+    }
+
+    private async Task ClearGuardInternalAsync(SqliteTransaction tx, CancellationToken ct) 
+        => await _connection.ExecuteAsync(new CommandDefinition(
+            "DELETE FROM pending_transaction WHERE id = 1", transaction: tx, cancellationToken: ct));
+
+    private async Task ClearGuardDurableAsync(string sessionId, CancellationToken ct) 
+        => await _connection.ExecuteAsync(new CommandDefinition(
+            "DELETE FROM pending_transaction WHERE id = 1 AND session_id = @sessionId",
+            new { sessionId }, cancellationToken: ct));
+
+    private async Task RollbackFilesystemAsync(byte[] targetHash, CancellationToken ct)
+    {
+        var engine = new RollbackEngine(_connection, _workspaceRoot, _ignoreSet);
+        await Task.Run(() => engine.RestoreTo(targetHash), ct);
+    }
+
+    private async Task<byte[]> GetCurrentHeadAsync(string sessionId, CancellationToken ct) 
+        => await _connection.ExecuteScalarAsync<byte[]>(new CommandDefinition(
+            "SELECT head_snap_hash FROM session_state WHERE session_id = @sid",
+            new { sid = sessionId }, cancellationToken: ct))
+        ?? throw new DxException(DxError.SessionNotFound, "Session HEAD missing.");
+}


### PR DESCRIPTION
## Summary
Refactor DX execution to enforce atomic, crash-safe mutation semantics via a dedicated TransactionCoordinator.

This change introduces a single authoritative transaction owner responsible for:
- pending transaction guards
- commit / rollback guarantees
- crash recovery ordering
- filesystem + database consistency

## Related Issue
Closes #27

## Type of Change
- [x] Refactor
- [x] Bug fix
- [x] Behavioral change
- [ ] Tests
- [ ] Documentation

## Changes
- Introduce `TransactionCoordinator` as the sole authority for mutating execution
- Enforce pending transaction exclusivity and recovery ordering
- Centralize commit / rollback semantics for filesystem and database state
- Correct rollback behavior for run-gate failures
- Correct exit-code mapping for base-mismatch rejections
- Eliminate schema-dependent assumptions in recovery logic

## Invariants / Contracts
- DX execution is atomic: mutations either fully commit or leave the workspace unchanged
- Pending transactions are always cleared on success or failure
- Crash recovery runs only before a new mutation starts
- Observable CLI exit codes reflect execution semantics (e.g. base mismatch → exit 3)

## Verification
- Full CLI integration suite exercised
- Transaction failure, rollback, recovery, and run-gate paths verified
- No remaining persistence corruption scenarios observed

## Known Out-of-Scope Issues
- `dxs pack --session-header` option (tracked separately; not part of execution semantics)

## Risks
Touches core execution and persistence layers. Changes are deliberately centralized to reduce long-term risk.

## Checklist
- [x] Builds cleanly
- [ ] All tests pass (final non-transactional CLI issues pending)
- [x] Transactional invariants validated
- [x] Logging and recovery consistency preserved