### PR TITLE
PR 43 — Observability: Canonical Dual‑Log Session Audit Trail

### DIFF
--- a/src/Dx.Cli/Commands/ApplyCommand.cs
+++ b/src/Dx.Cli/Commands/ApplyCommand.cs
@@ -1,4 +1,5 @@
 using Dx.Core;
+using Dx.Core.Execution.Results;
 using Dx.Core.Protocol;
 using Spectre.Console;
 using Spectre.Console.Cli;
@@ -103,50 +104,55 @@ public sealed class ApplyCommand : DxCommandBase<ApplySettings>
     /// <exception cref="DxException">
     /// Thrown when a DX-specific error occurs during execution.
     /// </exception>
-    public override async Task<int> ExecuteAsync(CommandContext ctx, ApplySettings s)
+    public override async Task<int> ExecuteAsync(CommandContext context, ApplySettings settings)
     {
         try
         {
-            var root = FindRoot(s.Root);
-            var runtime = DxRuntime.Open(root, s.Session, new ConsoleDxLogger(s.Verbose));
+            var workspaceRoot = FindRoot(settings.Root);
+            var runtime = DxRuntime.Open(workspaceRoot, settings.Session, new ConsoleDxLogger(settings.Verbose));
 
-            // Read document
             string text;
-            if (s.File == "-")
+
+            if (settings.File == "-")
+            {
                 text = await Console.In.ReadToEndAsync();
+            }
             else
-                text = await System.IO.File.ReadAllTextAsync(s.File);
+            {
+                text = await System.IO.File.ReadAllTextAsync(settings.File); 
+            }
 
             // Parse
-            var (doc, errors) = DxParser.ParseText(text);
+            var (document, errors) = DxParser.ParseText(text);
 
             if (errors.Count > 0)
             {
                 foreach (var e in errors)
+                {
                     Console.Error.WriteLine($"parse error line {e.Line}: {e.Message}");
+                }
+
                 return 2;
             }
 
-            if (doc is null)
+            if (document is null)
             {
                 Console.Error.WriteLine("error: Failed to parse document.");
                 return 2;
             }
 
-            if (s.DryRun)
+            if (settings.DryRun)
             {
                 AnsiConsole.MarkupLine("[yellow]dry run[/] — no changes applied.");
-                RenderDocumentSummary(doc);
+                RenderDocumentSummary(document);
                 return 0;
             }
 
-            // Build apply options from per-invocation flags
             var applyOptions = new ApplyOptions(
-                OnBaseMismatch: s.OnBaseMismatch,
-                RunTimeoutSeconds: s.RunTimeout > 0 ? s.RunTimeout : null);
+                OnBaseMismatch: settings.OnBaseMismatch,
+                RunTimeoutSeconds: settings.RunTimeout > 0 ? settings.RunTimeout : null);
 
-            // Apply with progress
-            DispatchResult result = null!;
+            DxResult result = null!;
 
             await AnsiConsole.Progress()
                 .AutoClear(true)
@@ -163,13 +169,25 @@ public sealed class ApplyCommand : DxCommandBase<ApplySettings>
                         task.Increment(10);
                     });
 
-                    result = await runtime.ApplyAsync(doc, isDryRun: false, progress,
+
+                    result = await runtime.ApplyAsync(
+                        document: document,
+                        rawText: text,
+                        direction: "user",
+                        isDryRun: false,
+                        progress: progress,
                         options: applyOptions);
                 });
 
             RenderApplyResult(result);
 
-            return result.Success ? 0 : (result.IsBaseMismatch ? 3 : 1);
+
+            return result.Status switch
+            {
+                DxResultStatus.Success => 0,
+                DxResultStatus.BaseMismatch => 3,
+                _ => 1
+            };
         }
         catch (DxException ex) { return HandleDxException(ex); }
         catch (Exception ex) { return HandleUnexpected(ex); }
@@ -184,11 +202,12 @@ public sealed class ApplyCommand : DxCommandBase<ApplySettings>
     /// Success output (table + handle) goes to stdout.
     /// Failure output goes to stderr so it does not pollute piped stdout.
     /// </remarks>
-    private static void RenderApplyResult(DispatchResult result)
+
+    private static void RenderApplyResult(DxResult result)
     {
-        if (!result.Success)
+        if (!result.IsSuccess)
         {
-            Console.Error.WriteLine($"error: {result.Error}");
+            Console.Error.WriteLine($"error: {result.Message}");
             Console.Error.WriteLine("Working tree rolled back.");
             return;
         }
@@ -199,7 +218,7 @@ public sealed class ApplyCommand : DxCommandBase<ApplySettings>
             .AddColumn("Path")
             .AddColumn("Result");
 
-        foreach (var op in result.Operations)
+        foreach (var op in result.Blocks)
         {
             var status = op.Success ? "[green]ok[/]" : "[red]failed[/]";
             table.AddRow(
@@ -208,10 +227,16 @@ public sealed class ApplyCommand : DxCommandBase<ApplySettings>
                 op.Detail is not null ? $"{status} {op.Detail}" : status);
         }
 
-        if (result.NewHandle is not null)
-            AnsiConsole.MarkupLine($"[green]→[/] [yellow]{result.NewHandle}[/]");
+        AnsiConsole.Write(table);
+
+        if (result.SnapId is not null)
+        {
+            AnsiConsole.MarkupLine($"[green]→[/] [yellow]{result.SnapId}[/]"); 
+        }
         else
+        {
             AnsiConsole.MarkupLine("[dim]No changes (no-op).[/]");
+        }
     }
 
     /// <summary>

--- a/src/Dx.Cli/Commands/ApplyCommand.cs
+++ b/src/Dx.Cli/Commands/ApplyCommand.cs
@@ -163,7 +163,7 @@ public sealed class ApplyCommand : DxCommandBase<ApplySettings>
                         task.Increment(10);
                     });
 
-                    result = await runtime.ApplyAsync(doc, dryRun: false, progress,
+                    result = await runtime.ApplyAsync(doc, isDryRun: false, progress,
                         options: applyOptions);
                 });
 

--- a/src/Dx.Core/DxDatabase.cs
+++ b/src/Dx.Core/DxDatabase.cs
@@ -155,7 +155,8 @@ file static class Migrations
     /// <summary>Gets the complete ordered list of schema migrations.</summary>
     public static readonly IReadOnlyList<Migration> All =
     [
-        new(1, V1Schema)
+        new(1, V1Schema),
+        new(2, V2_MakeTxSuccessNullable)
     ];
 
     /// <summary>
@@ -255,4 +256,50 @@ file static class Migrations
             FOREIGN KEY (session_id) REFERENCES sessions(session_id)
         );
         """;
+
+
+    /// <summary>
+    /// Version 2 migration:
+    /// Makes session_log.tx_success nullable in order to support the
+    /// Dual‑Log Invariant (input log + result log).
+    /// </summary>
+    private const string V2_MakeTxSuccessNullable = """
+    -- Rebuild session_log to allow tx_success = NULL
+    CREATE TABLE session_log_new (
+        id          INTEGER PRIMARY KEY AUTOINCREMENT,
+        session_id  TEXT    NOT NULL,
+        direction   TEXT    NOT NULL CHECK (direction IN ('llm','tool','user')),
+        document    TEXT    NOT NULL,
+        snap_handle TEXT,
+        tx_success  INTEGER NULL CHECK (tx_success IN (0,1)),
+        created_at  TEXT    NOT NULL,
+        FOREIGN KEY (session_id) REFERENCES sessions(session_id) ON DELETE RESTRICT
+    );
+
+    INSERT INTO session_log_new (
+        id,
+        session_id,
+        direction,
+        document,
+        snap_handle,
+        tx_success,
+        created_at
+    )
+    SELECT
+        id,
+        session_id,
+        direction,
+        document,
+        snap_handle,
+        tx_success,
+        created_at
+    FROM session_log;
+
+    DROP TABLE session_log;
+
+    ALTER TABLE session_log_new RENAME TO session_log;
+
+    CREATE INDEX IF NOT EXISTS idx_session_log_session
+        ON session_log(session_id, id);
+    """;
 }

--- a/src/Dx.Core/DxRuntime.cs
+++ b/src/Dx.Core/DxRuntime.cs
@@ -1,6 +1,8 @@
 using Dapper;
 
 using Dx.Core.Execution;
+using Dx.Core.Execution.Adapters;
+using Dx.Core.Execution.Results;
 using Dx.Core.Protocol;
 using Dx.Core.Storage;
 
@@ -132,39 +134,56 @@ public sealed class DxRuntime
     /// A <see cref="Protocol.DispatchResult"/> describing the outcome, including the
     /// new snapshot handle on success or an error message on failure.
     /// </returns>
-    public async Task<DispatchResult> ApplyAsync(
-            DxDocument document,
-            bool isDryRun = false,
-            IProgress<string>? progress = null,
-            ApplyOptions? options = null,
-            CancellationToken ct = default)
+    public async Task<DxResult> ApplyAsync(
+        DxDocument document,
+        string rawText,
+        string direction,
+        bool isDryRun = false,
+        IProgress<string>? progress = null,
+        ApplyOptions? options = null,
+        CancellationToken ct = default)
     {
-        // Always ensure pending_transaction is clean before any new dispatch
-        _connection.Execute("DELETE FROM pending_transaction WHERE id = 1");
+        ArgumentNullException.ThrowIfNull(document, nameof(document));
+        if (string.IsNullOrWhiteSpace(rawText))
+            throw new ArgumentException("Raw text must be provided to preserve intent and direction in the session log.", nameof(rawText));
+
+        if (string.IsNullOrWhiteSpace(direction))
+            throw new ArgumentException("Direction must be provided to preserve intent and direction in the session log.", nameof(direction));
+
+        // 1. Transaction Guard: Ensure pending_transaction is clean before any new dispatch
+        await _connection.ExecuteAsync("DELETE FROM pending_transaction WHERE id = 1", ct);
+
+        var store = new DxStore(_connection, _sessionId);
 
         var dispatcher = new DxDispatcher(
             _connection,
+            store,
             _workspaceRoot,
             IgnoreSet,
             _sessionId,
             _logger);
 
+        // 2. Authoritative Envelope: Capture intent and direction at the boundary.
         var request = new DxExecutionRequest(
-            document, 
-            isDryRun ? DxExecutionMode.DryRun : DxExecutionMode.Apply,
-            progress,
-            ct: ct);
+                Document: document,
+                RawText: rawText,
+                Direction: direction,
+                Mode: isDryRun ? DxExecutionMode.DryRun : DxExecutionMode.Apply,
+                IsDryRun: isDryRun,
+                Progress: progress,
+                Options: options,
+                CancellationToken: ct);
 
         return await dispatcher.DispatchAsync(request);
     }
 
     // ── Snap graph queries ────────────────────────────────────────────────────
 
-    /// <summary>
-    /// Returns an ordered list of all snapshot handles registered in the current session,
-    /// from oldest (T0000) to newest, with the HEAD marker resolved.
-    /// </summary>
-    /// <returns>A read-only list of <see cref="SnapInfo"/> records.</returns>
+        /// <summary>
+        /// Returns an ordered list of all snapshot handles registered in the current session,
+        /// from oldest (T0000) to newest, with the HEAD marker resolved.
+        /// </summary>
+        /// <returns>A read-only list of <see cref="SnapInfo"/> records.</returns>
     public IReadOnlyList<SnapInfo> ListSnaps()
         => _connection.Query<SnapInfo>(
             """

--- a/src/Dx.Core/DxRuntime.cs
+++ b/src/Dx.Core/DxRuntime.cs
@@ -2,6 +2,7 @@ using Dapper;
 
 using Dx.Core.Execution;
 using Dx.Core.Protocol;
+using Dx.Core.Storage;
 
 using Microsoft.Data.Sqlite;
 
@@ -15,16 +16,16 @@ namespace Dx.Core;
 public sealed class DxRuntime
 {
     private readonly IDxLogger _logger;
-    private readonly SqliteConnection _conn;
-    private readonly string _root;
+    private readonly SqliteConnection _connection;
+    private readonly string _workspaceRoot;
     private readonly string _sessionId;
 
     /// <summary>Gets the file exclusion rules for the active session, used to determine which files
     /// are included in snapshots and visible to DX operations.</summary>
     public IgnoreSet IgnoreSet { get; init; }
 
-    /// <param name="conn">An open database connection to the workspace <c>snap.db</c>.</param>
-    /// <param name="root">The absolute workspace root path.</param>
+    /// <param name="connection">An open database connection to the workspace <c>snap.db</c>.</param>
+    /// <param name="workspaceRoot">The absolute workspace root path.</param>
     /// <param name="sessionId">The identifier of the active session.</param>
     /// <param name="ignoreSet">The file exclusion rules for the active session.</param>
     /// <param name="logger">
@@ -32,14 +33,14 @@ public sealed class DxRuntime
     /// is used and all output is suppressed.
     /// </param>
     private DxRuntime(
-        SqliteConnection conn,
-        string root,
+        SqliteConnection connection,
+        string workspaceRoot,
         string sessionId,
         IgnoreSet ignoreSet,
         IDxLogger? logger = null)
     {
-        _conn = conn;
-        _root = root;
+        _connection = connection;
+        _workspaceRoot = workspaceRoot;
         _sessionId = sessionId;
         IgnoreSet = ignoreSet;
         _logger = logger ?? new NullDxLogger();
@@ -51,7 +52,7 @@ public sealed class DxRuntime
     /// Opens a <see cref="DxRuntime"/> instance for an existing workspace, resolving
     /// the most recent active session when <paramref name="sessionId"/> is not specified.
     /// </summary>
-    /// <param name="root">The workspace root directory.</param>
+    /// <param name="workspaceRoot">The workspace root directory.</param>
     /// <param name="sessionId">
     /// The session identifier to open. When <see langword="null"/>, the most recently
     /// created open session is used.
@@ -63,15 +64,15 @@ public sealed class DxRuntime
     /// directory is found, or with <see cref="DxError.SessionNotFound"/> when no active
     /// session exists or the specified session cannot be found.
     /// </exception>
-    public static DxRuntime Open(string root, string? sessionId = null, IDxLogger? logger = null)
+    public static DxRuntime Open(string workspaceRoot, string? sessionId = null, IDxLogger? logger = null)
     {
-        if (!IsWorkspace(root))
+        if (!IsWorkspace(workspaceRoot))
         {
             throw new DxException(DxError.WorkspaceNotInitialized,
-                $"No DX workspace found at {root}. Run 'dxs init' first.");
+                $"No DX workspace found at {workspaceRoot}. Run 'dxs init' first.");
         }
 
-        var conn = DxDatabase.Open(root);
+        var conn = DxDatabase.Open(workspaceRoot);
         DxDatabase.Migrate(conn);
 
         // Resolve session
@@ -88,7 +89,7 @@ public sealed class DxRuntime
 
         var ignoreSet = IgnoreSet.Deserialize(ignoreJson);
 
-        return new DxRuntime(conn, root, sessionId, ignoreSet, logger);
+        return new DxRuntime(conn, workspaceRoot, sessionId, ignoreSet, logger);
     }
 
     /// <summary>
@@ -96,50 +97,15 @@ public sealed class DxRuntime
     /// for the presence of the <c>.dx/</c> directory and the workspace database file
     /// <c>snap.db</c>.
     /// </summary>
-    /// <param name="root">The directory to check.</param>
+    /// <param name="workspaceRoot">The directory to check.</param>
     /// <returns><see langword="true"/> if the directory is a DX workspace root; otherwise, 
     /// <see langword="false"/>.</returns>
-    public static bool IsWorkspace(string root)
+    public static bool IsWorkspace(string workspaceRoot)
     {
-        var dxDir = Path.Combine(root, ".dx");
+        var dxDir = Path.Combine(workspaceRoot, ".dx");
         var dbPath = Path.Combine(dxDir, "snap.db");
 
         return Directory.Exists(dxDir) && File.Exists(dbPath);
-    }
-
-    // ── Init ──────────────────────────────────────────────────────────────────
-
-    /// <summary>
-    /// Initialises a new DX workspace at the given root path, creating the <c>.dx/</c>
-    /// directory, registering the genesis session, and taking the initial snapshot
-    /// <c>T0000</c> of the current working tree.
-    /// </summary>
-    /// <param name="root">The directory to initialise as a workspace.</param>
-    /// <param name="sessionId">The identifier to assign to the genesis session.</param>
-    /// <param name="artifactsDir">
-    /// An optional directory to exclude from all snapshots (e.g. a CI artifact output dir).
-    /// </param>
-    /// <param name="exclude">
-    /// An optional sequence of additional paths to exclude from snapshots.
-    /// </param>
-    /// <param name="includeBuildOutput">
-    /// When <see langword="true"/>, <c>bin/</c> and <c>obj/</c> are included in snapshots.
-    /// </param>
-    /// <param name="logger">An optional diagnostic logger.</param>
-    /// <returns>The handle assigned to the genesis snapshot (always <c>T0000</c>).</returns>
-    /// <exception cref="NotSupportedException">
-    /// Thrown unconditionally to prevent accidental misuse. This method is deprecated in favour of
-    /// the more robust and flexible combination of <see cref="WorkspaceInitializer"/> and
-    /// <see cref="SessionGenesisCreator"/>, which together provide a unified, deterministic source
-    /// of truth for workspace initialisation logic and ensure that all genesis creation flows
-    /// (e.g. <c>dxs init</c>, <c>dx session new</c>, and programmatic API usage) share the same 
-    /// underlying implementation.
-    /// </exception>
-    [Obsolete("DxRuntime.Init is deprecated. Use WorkspaceInitializer + SessionGenesisCreator.", true)]
-    public static void Init_Obsolete()
-    {
-        throw new NotSupportedException(
-            "DxRuntime.Init is removed. Use WorkspaceInitializer + SessionGenesisCreator.");
     }
 
     // ── Apply ─────────────────────────────────────────────────────────────────
@@ -148,8 +114,8 @@ public sealed class DxRuntime
     /// Applies a parsed <see cref="Protocol.DxDocument"/> as an atomic transaction,
     /// writing mutations to the working tree and creating a new snapshot on success.
     /// </summary>
-    /// <param name="doc">The parsed DX document to apply.</param>
-    /// <param name="dryRun">
+    /// <param name="document">The parsed DX document to apply.</param>
+    /// <param name="isDryRun">
     /// When <see langword="true"/>, validation is performed but no changes are written
     /// and no snapshot is created.
     /// </param>
@@ -166,26 +132,26 @@ public sealed class DxRuntime
     /// A <see cref="Protocol.DispatchResult"/> describing the outcome, including the
     /// new snapshot handle on success or an error message on failure.
     /// </returns>
-    public async Task<Protocol.DispatchResult> ApplyAsync(
-            Protocol.DxDocument doc,
-            bool dryRun = false,
+    public async Task<DispatchResult> ApplyAsync(
+            DxDocument document,
+            bool isDryRun = false,
             IProgress<string>? progress = null,
-            Protocol.ApplyOptions? options = null,
+            ApplyOptions? options = null,
             CancellationToken ct = default)
     {
         // Always ensure pending_transaction is clean before any new dispatch
-        _conn.Execute("DELETE FROM pending_transaction WHERE id = 1");
+        _connection.Execute("DELETE FROM pending_transaction WHERE id = 1");
 
-        var dispatcher = new Dx.Core.Protocol.DxDispatcher(
-            _conn,
-            _root,
+        var dispatcher = new DxDispatcher(
+            _connection,
+            _workspaceRoot,
             IgnoreSet,
             _sessionId,
             _logger);
 
         var request = new DxExecutionRequest(
-            doc, 
-            dryRun ? DxExecutionMode.DryRun : DxExecutionMode.Apply,
+            document, 
+            isDryRun ? DxExecutionMode.DryRun : DxExecutionMode.Apply,
             progress,
             ct: ct);
 
@@ -200,7 +166,7 @@ public sealed class DxRuntime
     /// </summary>
     /// <returns>A read-only list of <see cref="SnapInfo"/> records.</returns>
     public IReadOnlyList<SnapInfo> ListSnaps()
-        => _conn.Query<SnapInfo>(
+        => _connection.Query<SnapInfo>(
             """
             SELECT h.handle AS Handle,
                    h.seq    AS Seq,
@@ -219,14 +185,14 @@ public sealed class DxRuntime
     /// </summary>
     /// <returns>A handle string such as <c>T0003</c>, or <see langword="null"/>.</returns>
     public string? GetHead()
-            => _conn.ExecuteScalar<string>(
+            => _connection.ExecuteScalar<string>(
                 """
-            SELECT h.handle
-            FROM session_state ss
-            JOIN snap_handles h ON h.snap_hash = ss.head_snap_hash
-                               AND h.session_id = ss.session_id
-            WHERE ss.session_id = @sid
-            """,
+                SELECT h.handle
+                FROM session_state ss
+                JOIN snap_handles h ON h.snap_hash = ss.head_snap_hash
+                                   AND h.session_id = ss.session_id
+                WHERE ss.session_id = @sid
+                """,
                 new { sid = _sessionId });
 
     /// <summary>
@@ -242,7 +208,7 @@ public sealed class DxRuntime
     public IReadOnlyList<SnapFileInfo> GetSnapFiles(string handle)
     {
         var snapHash = ResolveHandle(handle);
-        return _conn.Query<SnapFileInfo>(
+        return _connection.Query<SnapFileInfo>(
             """
             SELECT path AS Path, size_bytes AS SizeBytes
             FROM snap_files
@@ -270,15 +236,15 @@ public sealed class DxRuntime
         var hashA = ResolveHandle(handleA);
         var hashB = ResolveHandle(handleB);
 
-        var filesA = _conn.Query<(string Path, byte[] ContentHash)>(
+        var filesA = _connection.Query<(string Path, byte[] ContentHash)>(
             "SELECT path, content_hash FROM snap_files WHERE snap_hash = @sh AND session_id = @sid",
-            new { sh = hashA, sid = _sessionId })
-            .ToDictionary(r => r.Path, r => r.ContentHash, StringComparer.Ordinal);
+            new { sh = hashA, sid = _sessionId }
+        ).ToDictionary(r => r.Path, r => r.ContentHash, StringComparer.Ordinal);
 
-        var filesB = _conn.Query<(string Path, byte[] ContentHash)>(
+        var filesB = _connection.Query<(string Path, byte[] ContentHash)>(
             "SELECT path, content_hash FROM snap_files WHERE snap_hash = @sh AND session_id = @sid",
-            new { sh = hashB, sid = _sessionId })
-            .ToDictionary(r => r.Path, r => r.ContentHash, StringComparer.Ordinal);
+            new { sh = hashB, sid = _sessionId }
+        ).ToDictionary(r => r.Path, r => r.ContentHash, StringComparer.Ordinal);
 
         var result = new List<DiffEntry>();
         var allPaths = filesA.Keys.Union(filesB.Keys).OrderBy(p => p).ToList();
@@ -327,26 +293,26 @@ public sealed class DxRuntime
         var targetHash = ResolveHandle(targetHandle);
 
         // 1. Acquire workspace lock to prevent concurrent mutations
-        var lockFile = Path.Combine(_root, ".dx", "snaps.lock");
+        var lockFile = Path.Combine(_workspaceRoot, ".dx", "snaps.lock");
         await using var dxLock = await DxLock.AcquireAsync(lockFile, TimeSpan.FromSeconds(5), ct);
 
         // 2. Perform the physical restoration
-        var engine = new RollbackEngine(_conn, _root, IgnoreSet);
+        var engine = new RollbackEngine(_connection, _workspaceRoot, IgnoreSet);
         engine.RestoreTo(targetHash);
 
         // 3. Re-snapshot to ensure HEAD matches the target state 
         // (and handle any untracked file interactions)
-        var manifest = ManifestBuilder.Build(_root, IgnoreSet);
+        var manifest = ManifestBuilder.Build(_workspaceRoot, IgnoreSet);
         var snapHash = ManifestBuilder.ComputeSnapHash(manifest);
 
-        var writer = new SnapshotWriter(_conn);
+        var writer = new SnapshotWriter(_connection);
         var newHandle = await writer.PersistAsync(_sessionId, snapHash, manifest, ct: ct);
 
         // PR 42 INVARIANT: Canonical Logging Authority for Checkout
         // Checkout is a state mutation occurring outside the DxDispatcher document protocol.
         // To maintain a complete linear audit trail, it must produce exactly one 
         // successful session_log entry.
-        await _conn.ExecuteAsync(new CommandDefinition(
+        await _connection.ExecuteAsync(new CommandDefinition(
             """
             INSERT INTO session_log 
             (session_id, direction, document, snap_handle, tx_success, created_at)
@@ -373,7 +339,7 @@ public sealed class DxRuntime
     /// <param name="limit">The maximum number of entries to return. Defaults to <c>100</c>.</param>
     /// <returns>A read-only list of <see cref="LogEntry"/> records.</returns>
     public IReadOnlyList<LogEntry> GetLog(int limit = 100)
-        => _conn.Query<LogEntry>(
+        => _connection.Query<LogEntry>(
             """
             SELECT id AS Id, direction AS Direction, snap_handle AS SnapHandle,
                    tx_success AS TxSuccess, created_at AS CreatedAt
@@ -392,6 +358,7 @@ public sealed class DxRuntime
     /// context.
     /// </summary>
     /// <param name="handle">The snapshot handle to materialise (e.g. <c>T0002</c>).</param>
+    /// <param name="ct">A cancellation token that can interrupt the operation.</param>
     /// <returns>
     /// A task that resolves to the absolute path of the temporary directory. The caller is
     /// responsible for deleting the directory when it is no longer needed.
@@ -399,7 +366,7 @@ public sealed class DxRuntime
     /// <exception cref="DxException">
     /// Thrown with <see cref="DxError.SnapNotFound"/> when the handle does not exist.
     /// </exception>
-    public Task<string> MaterializeSnapAsync(string handle)
+    public Task<string> MaterializeSnapAsync(string handle, CancellationToken ct = default)
     {
         var snapHash = ResolveHandle(handle);
 
@@ -410,7 +377,7 @@ public sealed class DxRuntime
         Directory.CreateDirectory(tempDir);
 
         // Fix #12 / #19: removed invalid namespace prefix on file-scoped type
-        var files = _conn.Query<SnapMaterializeRow>(
+        var files = _connection.Query<SnapMaterializeRow>(
             """
             SELECT sf.path         AS Path,
                    sf.content_hash AS ContentHash
@@ -421,7 +388,7 @@ public sealed class DxRuntime
             """,
             new { sh = snapHash, sid = _sessionId });
 
-        var store = new Storage.SqliteContentStore(_conn);
+        var store = new SqliteContentStore(_connection);
         foreach (var file in files)
         {
             var absPath = DxPath.ToAbsolute(tempDir, file.Path);
@@ -444,20 +411,9 @@ public sealed class DxRuntime
     /// <see cref="DxError.SnapNotFound"/> if the handle is unknown.
     /// </summary>
     private byte[] ResolveHandle(string handle)
-        => HandleAssigner.Resolve(_conn, _sessionId, handle)
+        => HandleAssigner.Resolve(_connection, _sessionId, handle)
            ?? throw new DxException(DxError.SnapNotFound,
                $"Snap not found: {handle}");
-
-    /// <summary>
-    /// Returns the raw SHA-256 hash of the current HEAD snapshot, throwing
-    /// <see cref="DxError.SessionNotFound"/> when the session has no HEAD record.
-    /// </summary>
-    private byte[] GetCurrentHeadHash()
-        => _conn.ExecuteScalar<byte[]>(
-            "SELECT head_snap_hash FROM session_state WHERE session_id = @sid",
-            new { sid = _sessionId })
-            ?? throw new DxException(DxError.SessionNotFound,
-                $"No HEAD for session: {_sessionId}");
 }
 
 /// <summary>

--- a/src/Dx.Core/Execution/Adapters/DxResultMapper.DispatchResult.cs
+++ b/src/Dx.Core/Execution/Adapters/DxResultMapper.DispatchResult.cs
@@ -5,55 +5,60 @@ using Dx.Core.Protocol;
 namespace Dx.Core.Execution.Adapters;
 
 /// <summary>
-/// Provides mapping from internal dispatch results to protocol-level results.
+/// Transitional mapper to convert legacy <see cref="DispatchResult"/> 
+/// into the canonical <see cref="DxResult"/> contract.
 /// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Lifecycle:</strong>
+/// This mapper exists solely to bridge legacy transaction results 
+/// during the execution pipeline migration.
+/// </para>
+/// <para>
+/// <strong>Removal Condition:</strong>
+/// Remove this class once internal execution layers return 
+/// <see cref="DxResult"/> natively (planned in PR 45).
+/// </para>
+/// </remarks>
 public static partial class DxResultMapper
 {
     /// <summary>
-    /// Converts a <see cref="DispatchResult"/> into a canonical <see cref="DxResult"/>.
+    /// Maps a legacy <see cref="DispatchResult"/> to an authoritative <see cref="DxResult"/>.
     /// </summary>
-    /// <param name="raw">The raw dispatch result.</param>
-    /// <param name="isDryRun">Indicates whether execution was a dry run.</param>
-    /// <returns>A normalized <see cref="DxResult"/>.</returns>
-    public static DxResult FromDispatchResult(
-        DispatchResult raw,
-        bool isDryRun)
+    /// <remarks>
+    /// <strong>Property Alignment:</strong>
+    /// <list type="bullet">
+    /// <item><description><c>Error</c> (Internal) -> <c>Message</c> (Canonical)</description></item>
+    /// <item><description><c>NewHandle</c> (Internal) -> <c>SnapId</c> (Canonical)</description></item>
+    /// </list>
+    /// </remarks>
+    [Obsolete("Temporary bridge. Remove in PR 45 when DispatchResult is retired.")]
+    public static DxResult ToDxResult(DispatchResult legacy, bool isDryRun)
     {
-        if (raw.Success)
-        {
-            if (isDryRun)
-                return FromDryRun();
+        var status = legacy.Success ? DxResultStatus.Success
+                   : legacy.IsBaseMismatch ? DxResultStatus.BaseMismatch
+                   : DxResultStatus.ExecutionFailure;
 
-            return FromSuccess(raw.NewHandle);
-        }
+        var diagnostics = new List<DxDiagnostic>();
 
-        if (raw.IsBaseMismatch)
+        // GOLDEN INVARIANT: If it failed, there MUST be a diagnostic.
+        if (!legacy.Success)
         {
-            return new DxResult(
-                DxResultStatus.BaseMismatch,
-                raw.Error,
-                snapId: null,
-                diagnostics: new[]
-                {
-                    new DxDiagnostic(
-                        "BASE_MISMATCH",
-                        raw.Error ?? "Base mismatch",
-                        DxDiagnosticSeverity.Error)
-                },
-                isDryRun: false);
+            diagnostics.Add(new DxDiagnostic(
+                code: legacy.IsBaseMismatch ? "BASE_MISMATCH" : "EXECUTION_ERROR",
+                message: legacy.Error ?? "An unknown execution error occurred.",
+                severity: DxDiagnosticSeverity.Error
+            ));
         }
 
         return new DxResult(
-            DxResultStatus.ExecutionFailure,
-            raw.Error ?? "Execution failed",
-            snapId: null,
-            diagnostics: new[]
-            {
-                new DxDiagnostic(
-                    "EXECUTION_FAILURE",
-                    raw.Error ?? "Execution failed",
-                    DxDiagnosticSeverity.Error)
-            },
-            isDryRun: false);
+            status: status,
+            message: legacy.Error,
+            snapId: legacy.NewHandle,
+            diagnostics: diagnostics,
+            isDryRun: isDryRun,
+            metadata: null,
+            blocks: legacy.Operations
+        );
     }
 }

--- a/src/Dx.Core/Execution/Results/DxResult.Cancellation..cs
+++ b/src/Dx.Core/Execution/Results/DxResult.Cancellation..cs
@@ -2,7 +2,7 @@ using Dx.Core.Protocol;
 
 namespace Dx.Core.Execution.Results;
 
-public sealed partial class DxResult
+public sealed partial record DxResult
 {
     /// <summary>
     /// Creates a standardized cancellation result.

--- a/src/Dx.Core/Execution/Results/DxResult.cs
+++ b/src/Dx.Core/Execution/Results/DxResult.cs
@@ -1,5 +1,7 @@
 namespace Dx.Core.Execution.Results;
 
+using Dx.Core.Protocol;
+
 /// <summary>
 /// Represents the complete, immutable outcome of a Dx execution.
 /// </summary>
@@ -14,12 +16,12 @@ namespace Dx.Core.Execution.Results;
 /// without concern for mutation.
 /// </para>
 /// </remarks>
-public sealed partial class DxResult
+public sealed partial record DxResult
 {
     /// <summary>
     /// Gets the high-level execution status.
     /// </summary>
-    public DxResultStatus Status { get; }
+    public DxResultStatus Status { get; init; }
 
     /// <summary>
     /// Gets an optional summary message describing the execution outcome.
@@ -28,7 +30,7 @@ public sealed partial class DxResult
     /// May be <see langword="null"/> when the status alone is sufficient
     /// to describe the outcome.
     /// </value>
-    public string? Message { get; }
+    public string? Message { get; init; }
 
     /// <summary>
     /// Gets the snapshot identifier produced or evaluated during execution.
@@ -37,7 +39,7 @@ public sealed partial class DxResult
     /// Returns <see langword="null"/> when execution did not produce
     /// or evaluate a snapshot.
     /// </value>
-    public string? SnapId { get; }
+    public string? SnapId { get; init; }
 
     /// <summary>
     /// Gets the collection of diagnostics generated during execution.
@@ -45,13 +47,13 @@ public sealed partial class DxResult
     /// <value>
     /// Guaranteed to be non-null. May be empty.
     /// </value>
-    public IReadOnlyList<DxDiagnostic> Diagnostics { get; }
+    public IReadOnlyList<DxDiagnostic> Diagnostics { get; init; }
 
     /// <summary>
     /// Gets a value indicating whether the execution was evaluated
     /// in dry-run mode.
     /// </summary>
-    public bool IsDryRun { get; }
+    public bool IsDryRun { get; init; }
 
     /// <summary>
     /// Gets optional structured metadata associated with the result.
@@ -60,7 +62,31 @@ public sealed partial class DxResult
     /// Intended for advanced consumers and tooling integrations.
     /// Consumers should not rely on undocumented keys.
     /// </remarks>
-    public IReadOnlyDictionary<string, object>? Metadata { get; }
+    public IReadOnlyDictionary<string, object>? Metadata { get; init; }
+
+    /// <summary>
+    /// Gets the list of individual block execution outcomes.
+    /// </summary>
+    /// <remarks>
+    /// This property provides the granular audit trail for each block in the source document.
+    /// It is required for canonical result serialization and is guaranteed to be non-null.
+    /// </remarks>
+    public IReadOnlyList<OperationResult> Blocks { get; init; } = Array.Empty<OperationResult>();
+
+    /// <summary>
+    /// Gets a value indicating whether the result represents a successful operation.
+    /// </summary>
+    public bool IsSuccess => Status == DxResultStatus.Success;
+
+    /// <summary>
+    /// Gets a value indicating whether the execution resulted in a permanent state change
+    /// being committed to the workspace.
+    /// </summary>
+    /// <remarks>
+    /// This property is <see langword="true"/> only if the execution was successful 
+    /// and was not a dry run.
+    /// </remarks>
+    public bool IsCommitted => IsSuccess && !IsDryRun;
 
     /// <summary>
     /// Gets a value indicating whether the execution represents failure.
@@ -87,12 +113,12 @@ public sealed partial class DxResult
     /// <param name="isDryRun">Indicates whether execution was a dry run.</param>
     /// <param name="metadata">Optional structured metadata.</param>
     public DxResult(
-        DxResultStatus status,
-        string? message,
-        string? snapId,
-        IReadOnlyList<DxDiagnostic>? diagnostics,
-        bool isDryRun,
-        IReadOnlyDictionary<string, object>? metadata = null)
+            DxResultStatus status,
+            string? message,
+            string? snapId,
+            IReadOnlyList<DxDiagnostic>? diagnostics,
+            bool isDryRun,
+            IReadOnlyDictionary<string, object>? metadata = null)
     {
         Status = status;
         Message = message;
@@ -100,19 +126,18 @@ public sealed partial class DxResult
         Diagnostics = diagnostics ?? Array.Empty<DxDiagnostic>();
         IsDryRun = isDryRun;
         Metadata = metadata;
+        Blocks = Array.Empty<OperationResult>(); // Explicit DX-First Initialization
     }
 
     /// <summary>
-    /// Deconstructs the result into its component properties, allowing for deconstruction assignment syntax
-    /// (e.g. <c>var (status, message, snapId, diagnostics, isDryRun, metadata) = result;</c>).
+    /// Deconstructs the result into its component properties.
     /// </summary>
-    /// <param name="status">When this method returns, contains the status of the result.</param>
-    /// <param name="message">When this method returns, contains the message associated with the result, or null if no message is present.</param>
-    /// <param name="snapId">When this method returns, contains the snapshot identifier, or null if not applicable.</param>
-    /// <param name="diagnostics">When this method returns, contains a read-only list of diagnostics associated with the result.</param>
-    /// <param name="isDryRun">When this method returns, indicates whether the operation was a dry run.</param>
-    /// <param name="metadata">When this method returns, contains a read-only dictionary of metadata associated with the result, or null if no
-    /// metadata is present.</param>
+    /// <param name="status">The result status.</param>
+    /// <param name="message">The result message.</param>
+    /// <param name="snapId">The snapshot identifier.</param>
+    /// <param name="diagnostics">The diagnostics list.</param>
+    /// <param name="isDryRun">Whether it was a dry run.</param>
+    /// <param name="metadata">The metadata dictionary.</param>
     public void Deconstruct(
         out DxResultStatus status,
         out string? message,

--- a/src/Dx.Core/Execution/Results/DxResult.cs
+++ b/src/Dx.Core/Execution/Results/DxResult.cs
@@ -5,23 +5,43 @@ using Dx.Core.Protocol;
 /// <summary>
 /// Represents the complete, immutable outcome of a Dx execution.
 /// </summary>
+/// <param name="status">The terminal execution status.</param>
+/// <param name="message">An optional summary message.</param>
+/// <param name="snapId">An optional snapshot identifier.</param>
+/// <param name="diagnostics">
+/// The collection of diagnostics produced during execution.
+/// If <see langword="null"/>, an empty collection is used.
+/// </param>
+/// <param name="isDryRun">Indicates whether execution was a dry run.</param>
+/// <param name="metadata">Optional structured metadata.</param>
+/// <param name="blocks">The list of individual block execution outcomes.</param>
 /// <remarks>
 /// <para>
 /// <see cref="DxResult"/> is the canonical execution contract between
-/// the engine, CLI, and automation layers.
+/// the engine, CLI, and automation layers. Instances must be treated as 
+/// terminal and stable once created. Consumers may safely cache, serialize, 
+/// or evaluate the result without concern for mutation.
 /// </para>
 /// <para>
-/// Instances must be treated as terminal and stable once created.
-/// Consumers may safely cache, serialize, or evaluate the result
-/// without concern for mutation.
+/// <strong>Black Box Contract:</strong>
+/// This type represents execution outcome only.
+/// It must not expose source document structure,
+/// execution intent, or environmental context.
 /// </para>
 /// </remarks>
-public sealed partial record DxResult
+public sealed partial record DxResult(
+    DxResultStatus status,
+    string? message,
+    string? snapId,
+    IReadOnlyList<DxDiagnostic>? diagnostics,
+    bool isDryRun,
+    IReadOnlyDictionary<string, object>? metadata = null,
+    IReadOnlyList<OperationResult>? blocks = null)
 {
     /// <summary>
     /// Gets the high-level execution status.
     /// </summary>
-    public DxResultStatus Status { get; init; }
+    public DxResultStatus Status { get; init; } = status;
 
     /// <summary>
     /// Gets an optional summary message describing the execution outcome.
@@ -30,7 +50,7 @@ public sealed partial record DxResult
     /// May be <see langword="null"/> when the status alone is sufficient
     /// to describe the outcome.
     /// </value>
-    public string? Message { get; init; }
+    public string? Message { get; init; } = message;
 
     /// <summary>
     /// Gets the snapshot identifier produced or evaluated during execution.
@@ -39,7 +59,7 @@ public sealed partial record DxResult
     /// Returns <see langword="null"/> when execution did not produce
     /// or evaluate a snapshot.
     /// </value>
-    public string? SnapId { get; init; }
+    public string? SnapId { get; init; } = snapId;
 
     /// <summary>
     /// Gets the collection of diagnostics generated during execution.
@@ -47,13 +67,13 @@ public sealed partial record DxResult
     /// <value>
     /// Guaranteed to be non-null. May be empty.
     /// </value>
-    public IReadOnlyList<DxDiagnostic> Diagnostics { get; init; }
+    public IReadOnlyList<DxDiagnostic> Diagnostics { get; init; } = diagnostics ?? Array.Empty<DxDiagnostic>();
 
     /// <summary>
     /// Gets a value indicating whether the execution was evaluated
     /// in dry-run mode.
     /// </summary>
-    public bool IsDryRun { get; init; }
+    public bool IsDryRun { get; init; } = isDryRun;
 
     /// <summary>
     /// Gets optional structured metadata associated with the result.
@@ -62,7 +82,7 @@ public sealed partial record DxResult
     /// Intended for advanced consumers and tooling integrations.
     /// Consumers should not rely on undocumented keys.
     /// </remarks>
-    public IReadOnlyDictionary<string, object>? Metadata { get; init; }
+    public IReadOnlyDictionary<string, object> Metadata { get; init; } = metadata ?? new Dictionary<string, object>();
 
     /// <summary>
     /// Gets the list of individual block execution outcomes.
@@ -71,7 +91,7 @@ public sealed partial record DxResult
     /// This property provides the granular audit trail for each block in the source document.
     /// It is required for canonical result serialization and is guaranteed to be non-null.
     /// </remarks>
-    public IReadOnlyList<OperationResult> Blocks { get; init; } = Array.Empty<OperationResult>();
+    public IReadOnlyList<OperationResult> Blocks { get; init; } = blocks ?? Array.Empty<OperationResult>();
 
     /// <summary>
     /// Gets a value indicating whether the result represents a successful operation.
@@ -99,35 +119,6 @@ public sealed partial record DxResult
         Status is DxResultStatus.BaseMismatch
                or DxResultStatus.ValidationFailure
                or DxResultStatus.ExecutionFailure;
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="DxResult"/> class.
-    /// </summary>
-    /// <param name="status">The terminal execution status.</param>
-    /// <param name="message">An optional summary message.</param>
-    /// <param name="snapId">An optional snapshot identifier.</param>
-    /// <param name="diagnostics">
-    /// The collection of diagnostics produced during execution.
-    /// If <see langword="null"/>, an empty collection is used.
-    /// </param>
-    /// <param name="isDryRun">Indicates whether execution was a dry run.</param>
-    /// <param name="metadata">Optional structured metadata.</param>
-    public DxResult(
-            DxResultStatus status,
-            string? message,
-            string? snapId,
-            IReadOnlyList<DxDiagnostic>? diagnostics,
-            bool isDryRun,
-            IReadOnlyDictionary<string, object>? metadata = null)
-    {
-        Status = status;
-        Message = message;
-        SnapId = snapId;
-        Diagnostics = diagnostics ?? Array.Empty<DxDiagnostic>();
-        IsDryRun = isDryRun;
-        Metadata = metadata;
-        Blocks = Array.Empty<OperationResult>(); // Explicit DX-First Initialization
-    }
 
     /// <summary>
     /// Deconstructs the result into its component properties.

--- a/src/Dx.Core/Protocol/DxDispatcher.cs
+++ b/src/Dx.Core/Protocol/DxDispatcher.cs
@@ -13,119 +13,133 @@ using System.Text;
 namespace Dx.Core.Protocol;
 
 /// <summary>
-/// Dispatches an execution request according to the transactional protocol.
-/// This is the single, authoritative entry point for all DX document execution.
+/// The authoritative protocol engine responsible for the atomic execution 
+/// of DX documents and the maintenance of the session audit trail.
 /// </summary>
-/// <param name="request">The encapsulated execution context.</param>
-/// <returns>A <see cref="DispatchResult"/> describing the outcome.</returns>
 /// <remarks>
-/// <para><strong>Invariant:</strong> Only mutating executions produce a <c>session_log</c> entry.</para>
-/// <para><strong>Invariant:</strong> Every mutating execution produces exactly one canonical log entry.</para>
+/// <para>
+/// <strong>Protocol Authority:</strong>
+/// This type is the sole authority for executing DX documents and producing 
+/// authoritative session audit records.
+/// </para>
+/// <para>
+/// <strong>Invariants:</strong>
+/// <list type="bullet">
+/// <item>
+/// <description>No execution may occur outside this dispatcher.</description>
+/// </item>
+/// <item>
+/// <description>Every execution attempt produces exactly two audit log entries 
+/// (input intent, execution result).</description>
+/// </item>
+/// <item>
+/// <description>This type must not interpret CLI-specific semantics.</description>
+/// </item>
+/// </list>
+/// </para>
 /// </remarks>
-public sealed class DxDispatcher
-{
-    private readonly IDxLogger _logger;
-    private readonly SqliteConnection _connection;
-    private readonly string _workspaceRoot;
-    private readonly IgnoreSet _ignoreSet;
-    private readonly string _sessionId;
-
-    public DxDispatcher(
+public sealed class DxDispatcher(
         SqliteConnection connection,
+        IDxStore store,
         string workspaceRoot,
         IgnoreSet ignoreSet,
         string sessionId,
         IDxLogger? logger = null)
+{
+    private readonly SqliteConnection _connection = connection ?? throw new ArgumentNullException(nameof(connection));
+    private readonly IDxStore _store = store ?? throw new ArgumentNullException(nameof(store));
+    private readonly string _workspaceRoot = workspaceRoot ?? throw new ArgumentNullException(nameof(workspaceRoot));
+    private readonly IgnoreSet _ignoreSet = ignoreSet ?? throw new ArgumentNullException(nameof(ignoreSet));
+    private readonly string _sessionId = sessionId ?? throw new ArgumentNullException(nameof(sessionId));
+    private readonly IDxLogger _logger = logger ?? NullDxLogger.Instance;
+
+    /// <summary>
+    /// Dispatches an execution request according to the transactional protocol.
+    /// This is the single, authoritative entry point for all DX document execution.
+    /// </summary>
+    public async Task<DxResult> DispatchAsync(DxExecutionRequest request)
     {
-        _connection = connection ?? throw new ArgumentNullException(nameof(connection));
-        _workspaceRoot = workspaceRoot ?? throw new ArgumentNullException(nameof(workspaceRoot));
-        _ignoreSet = ignoreSet ?? throw new ArgumentNullException(nameof(ignoreSet));
-        _sessionId = sessionId ?? throw new ArgumentNullException(nameof(sessionId));
-        _logger = logger ?? NullDxLogger.Instance;
-    }
+        ArgumentNullException.ThrowIfNull(request);
+        var (document, rawText, direction, _, isDryRun, progress, options, ct) = request;
 
-        /// <summary>
-        /// Dispatches an execution request according to the transactional protocol.
-        /// This is the single, authoritative entry point for all DX document execution.
-        /// </summary>
-        public async Task<DispatchResult> DispatchAsync(DxExecutionRequest request)
+        // 1. Authoritative Input Logging (Pre-Execution)
+        await _store.WriteSessionLogAsync(new SessionLogEntry
         {
-            ArgumentNullException.ThrowIfNull(request);
-            var (document, _, isDryRun, _, options, ct) = request;
+            SessionId = _sessionId,
+            Direction = direction,
+            Document = rawText,
+            TxSuccess = null,
+            SnapHandle = null
+        }, ct);
 
-            // 1. Authoritative Input Logging (Pre-Execution)
-            await _store.WriteSessionLogAsync(new SessionLogEntry
+        DxResult result;
+
+        try
+        {
+            if (!document.IsMutating)
             {
-                Direction = options?.Direction ?? "llm",
-                Document = request.Document.RawText,
-                TxSuccess = null,
-                SnapHandle = null
-            }, ct);
+                _logger.Debug("Document is read-only.");
+                var roOps = new List<OperationResult>();
 
-            DxResult result;
-
-            try
-            {
-                if (!document.IsMutating)
+                foreach (var block in document.Blocks)
                 {
-                    var roOps = new List<OperationResult>();
-                    foreach (var block in document.Blocks)
-                    {
-                        await DispatchReadOnlyBlockAsync(block, roOps, options, ct);
-                    }
-                    result = new DxResult(DxResultStatus.Success, null, null, null, isDryRun) { Blocks = roOps };
+                    await DispatchReadOnlyBlockAsync(block, roOps, options, ct);
                 }
-                else
-                {
-                    var dispatchResult = await ExecuteMutatingTransactionAsync(document, isDryRun, request.Progress, options, ct);
-                    result = DxResultMapper.ToDxResult(dispatchResult) with { Blocks = dispatchResult.Operations };
-                }
+
+                result = new DxResult(DxResultStatus.Success, null, null, null, isDryRun, null, roOps);
             }
-            catch (Exception ex)
+            else
             {
-                result = new DxResult(DxResultStatus.ExecutionFailure, ex.Message, null, null, isDryRun);
+                var dispatchResult = await ExecuteMutatingTransactionAsync(document, isDryRun, progress, options, ct);
+                result = DxResultMapper.ToDxResult(dispatchResult, isDryRun);
             }
-
-            // 2. Authoritative Output Logging (Post-Execution)
-            string resultDoc = DxResultLoggingSerializer.Serialize(result);
-
-            await _store.WriteSessionLogAsync(new SessionLogEntry
-            {
-                Direction = options?.Direction ?? "llm",
-                Document = resultDoc,
-                TxSuccess = result.IsSuccess ? 1 : 0,
-                SnapHandle = result.SnapId
-            }, ct);
-
-            return result;
+        }
+        catch (Exception ex)
+        {
+            result = new DxResult(DxResultStatus.ExecutionFailure, ex.Message, null, null, isDryRun, null, null);
         }
 
-        /// <summary>
-        /// Executes a mutating transaction on the specified document, applying all mutation and run blocks, and commits the
-        /// resulting state to the workspace.
-        /// </summary>
-        /// <remarks>This method acquires a workspace lock to ensure exclusive access during the transaction. If
-        /// the document's base does not match the current workspace state, the transaction may be rejected or a warning
-        /// issued, depending on the provided options. Failure logs are recorded even if the transaction is aborted,
-        /// ensuring audit continuity.</remarks>
-        /// <param name="document">The document containing mutation and run blocks to be applied as part of the transaction.</param>
-        /// <param name="dryRun">If <see langword="true"/>, simulates the transaction without persisting any changes or creating a log entry;
-        /// otherwise, applies and commits the mutations.</param>
-        /// <param name="progress">An optional progress reporter that receives status messages as the transaction progresses. May be <see
-        /// langword="null"/>.</param>
-        /// <param name="options">Optional settings that control transaction behavior, such as base mismatch handling and run block timeouts. May
-        /// be <see langword="null"/>.</param>
-        /// <param name="ct">A cancellation token that can be used to cancel the transaction operation.</param>
-        /// <returns>A <see cref="DispatchResult"/> indicating the outcome of the transaction, including success status, resulting
-        /// handle, error messages, and a list of operation results.</returns>
-        /// <exception cref="DxException">Thrown if a run block fails during the commit-gate phase or if an invalid argument is encountered in a run
-        /// block.</exception>
-        private async Task<DispatchResult> ExecuteMutatingTransactionAsync(
-                    DxDocument document,
-                    bool dryRun,
-                    IProgress<string>? progress,
-                    ApplyOptions? options,
-                    CancellationToken ct)
+        // 2. Authoritative Output Logging (Post-Execution)
+        string resultDocument = DxResultLoggingSerializer.Serialize(result);
+
+        await _store.WriteSessionLogAsync(new SessionLogEntry
+        {
+            SessionId = _sessionId,
+            Direction = direction,
+            Document = resultDocument,
+            TxSuccess = result.IsSuccess ? 1 : 0,
+            SnapHandle = result.SnapId
+        }, ct);
+
+        return result;
+    }
+
+    /// <summary>
+    /// Executes a mutating transaction on the specified document, applying all mutation and run blocks, and commits the
+    /// resulting state to the workspace.
+    /// </summary>
+    /// <remarks>This method acquires a workspace lock to ensure exclusive access during the transaction. If
+    /// the document's base does not match the current workspace state, the transaction may be rejected or a warning
+    /// issued, depending on the provided options. Failure logs are recorded even if the transaction is aborted,
+    /// ensuring audit continuity.</remarks>
+    /// <param name="document">The document containing mutation and run blocks to be applied as part of the transaction.</param>
+    /// <param name="dryRun">If <see langword="true"/>, simulates the transaction without persisting any changes or creating a log entry;
+    /// otherwise, applies and commits the mutations.</param>
+    /// <param name="progress">An optional progress reporter that receives status messages as the transaction progresses. May be <see
+    /// langword="null"/>.</param>
+    /// <param name="options">Optional settings that control transaction behavior, such as base mismatch handling and run block timeouts. May
+    /// be <see langword="null"/>.</param>
+    /// <param name="ct">A cancellation token that can be used to cancel the transaction operation.</param>
+    /// <returns>A <see cref="DispatchResult"/> indicating the outcome of the transaction, including success status, resulting
+    /// handle, error messages, and a list of operation results.</returns>
+    /// <exception cref="DxException">Thrown if a run block fails during the commit-gate phase or if an invalid argument is encountered in a run
+    /// block.</exception>
+    private async Task<DispatchResult> ExecuteMutatingTransactionAsync(
+                DxDocument document,
+                bool dryRun,
+                IProgress<string>? progress,
+                ApplyOptions? options,
+                CancellationToken ct)
     {
         var lockFile = Path.Combine(_workspaceRoot, ".dx", "snaps.lock");
         await using var dxLock = await DxLock.AcquireAsync(lockFile, TimeSpan.FromSeconds(5), ct);
@@ -529,10 +543,10 @@ public sealed class DxDispatcher
 
         if (bytes.Length >= 2 && bytes[0] == 0xFF && bytes[1] == 0xFE)
             return Encoding.Unicode;
-        
+
         if (bytes.Length >= 2 && bytes[0] == 0xFE && bytes[1] == 0xFF)
             return Encoding.BigEndianUnicode;
-        
+
         return new UTF8Encoding(false);
     }
 

--- a/src/Dx.Core/Protocol/DxDispatcher.cs
+++ b/src/Dx.Core/Protocol/DxDispatcher.cs
@@ -1,23 +1,26 @@
 using Dapper;
 
 using Dx.Core.Execution;
+using Dx.Core.Execution.Adapters;
+using Dx.Core.Execution.Results;
 using Dx.Core.Storage;
 
 using Microsoft.Data.Sqlite;
 
+using System.Diagnostics;
 using System.Text;
 
 namespace Dx.Core.Protocol;
 
 /// <summary>
-/// Executes a <see cref="DxDocument"/> against the workspace working tree and database,
-/// orchestrating the application of individual blocks and verifying run-gates.
+/// Dispatches an execution request according to the transactional protocol.
+/// This is the single, authoritative entry point for all DX document execution.
 /// </summary>
+/// <param name="request">The encapsulated execution context.</param>
+/// <returns>A <see cref="DispatchResult"/> describing the outcome.</returns>
 /// <remarks>
-/// This class enforces the transactional integrity of the DX protocol by delegating 
-/// all mutating operations to the <see cref="TransactionCoordinator"/>. It ensures 
-/// that no filesystem changes occur without crash recovery protection and 
-/// atomicity guarantees.
+/// <para><strong>Invariant:</strong> Only mutating executions produce a <c>session_log</c> entry.</para>
+/// <para><strong>Invariant:</strong> Every mutating execution produces exactly one canonical log entry.</para>
 /// </remarks>
 public sealed class DxDispatcher
 {
@@ -41,65 +44,88 @@ public sealed class DxDispatcher
         _logger = logger ?? NullDxLogger.Instance;
     }
 
-    /// <summary>
-    /// Dispatches an execution request according to the transactional protocol.
-    /// This is the single, authoritative entry point for all DX document execution.
-    /// </summary>
-    /// <param name="request">The encapsulated execution context.</param>
-    /// <returns>A <see cref="DispatchResult"/> describing the outcome.</returns>
-    /// <remarks>
-    /// <para><strong>Invariant:</strong> Only mutating executions produce a <c>session_log</c> entry.</para>
-    /// <para><strong>Invariant:</strong> Every mutating execution produces exactly one canonical log entry.</para>
-    /// </remarks>
-    public async Task<DispatchResult> DispatchAsync(DxExecutionRequest request)
-    {
-        ArgumentNullException.ThrowIfNull(request);
-
-        // Corrected deconstruction to match DxExecutionRequest.Deconstruct signature
-        var (document, mode, isDryRun, progress, options, ct) = request;
-
-        if (!document.IsMutating)
+        /// <summary>
+        /// Dispatches an execution request according to the transactional protocol.
+        /// This is the single, authoritative entry point for all DX document execution.
+        /// </summary>
+        public async Task<DispatchResult> DispatchAsync(DxExecutionRequest request)
         {
-            _logger.Debug("Document is read-only — producing no audit trail.");
-            var roOps = new List<OperationResult>();
+            ArgumentNullException.ThrowIfNull(request);
+            var (document, _, isDryRun, _, options, ct) = request;
 
-            foreach (var block in document.Blocks)
+            // 1. Authoritative Input Logging (Pre-Execution)
+            await _store.WriteSessionLogAsync(new SessionLogEntry
             {
-                await DispatchReadOnlyBlockAsync(block, roOps, options, ct);
+                Direction = options?.Direction ?? "llm",
+                Document = request.Document.RawText,
+                TxSuccess = null,
+                SnapHandle = null
+            }, ct);
+
+            DxResult result;
+
+            try
+            {
+                if (!document.IsMutating)
+                {
+                    var roOps = new List<OperationResult>();
+                    foreach (var block in document.Blocks)
+                    {
+                        await DispatchReadOnlyBlockAsync(block, roOps, options, ct);
+                    }
+                    result = new DxResult(DxResultStatus.Success, null, null, null, isDryRun) { Blocks = roOps };
+                }
+                else
+                {
+                    var dispatchResult = await ExecuteMutatingTransactionAsync(document, isDryRun, request.Progress, options, ct);
+                    result = DxResultMapper.ToDxResult(dispatchResult) with { Blocks = dispatchResult.Operations };
+                }
+            }
+            catch (Exception ex)
+            {
+                result = new DxResult(DxResultStatus.ExecutionFailure, ex.Message, null, null, isDryRun);
             }
 
-            return new DispatchResult(true, null, null, roOps);
+            // 2. Authoritative Output Logging (Post-Execution)
+            string resultDoc = DxResultLoggingSerializer.Serialize(result);
+
+            await _store.WriteSessionLogAsync(new SessionLogEntry
+            {
+                Direction = options?.Direction ?? "llm",
+                Document = resultDoc,
+                TxSuccess = result.IsSuccess ? 1 : 0,
+                SnapHandle = result.SnapId
+            }, ct);
+
+            return result;
         }
 
-        return await ExecuteMutatingTransactionAsync(document, isDryRun, progress, options, ct);
-    }
-
-    /// <summary>
-    /// Executes a mutating transaction on the specified document, applying all mutation and run blocks, and commits the
-    /// resulting state to the workspace.
-    /// </summary>
-    /// <remarks>This method acquires a workspace lock to ensure exclusive access during the transaction. If
-    /// the document's base does not match the current workspace state, the transaction may be rejected or a warning
-    /// issued, depending on the provided options. Failure logs are recorded even if the transaction is aborted,
-    /// ensuring audit continuity.</remarks>
-    /// <param name="document">The document containing mutation and run blocks to be applied as part of the transaction.</param>
-    /// <param name="dryRun">If <see langword="true"/>, simulates the transaction without persisting any changes or creating a log entry;
-    /// otherwise, applies and commits the mutations.</param>
-    /// <param name="progress">An optional progress reporter that receives status messages as the transaction progresses. May be <see
-    /// langword="null"/>.</param>
-    /// <param name="options">Optional settings that control transaction behavior, such as base mismatch handling and run block timeouts. May
-    /// be <see langword="null"/>.</param>
-    /// <param name="ct">A cancellation token that can be used to cancel the transaction operation.</param>
-    /// <returns>A <see cref="DispatchResult"/> indicating the outcome of the transaction, including success status, resulting
-    /// handle, error messages, and a list of operation results.</returns>
-    /// <exception cref="DxException">Thrown if a run block fails during the commit-gate phase or if an invalid argument is encountered in a run
-    /// block.</exception>
-    private async Task<DispatchResult> ExecuteMutatingTransactionAsync(
-                DxDocument document,
-                bool dryRun,
-                IProgress<string>? progress,
-                ApplyOptions? options,
-                CancellationToken ct)
+        /// <summary>
+        /// Executes a mutating transaction on the specified document, applying all mutation and run blocks, and commits the
+        /// resulting state to the workspace.
+        /// </summary>
+        /// <remarks>This method acquires a workspace lock to ensure exclusive access during the transaction. If
+        /// the document's base does not match the current workspace state, the transaction may be rejected or a warning
+        /// issued, depending on the provided options. Failure logs are recorded even if the transaction is aborted,
+        /// ensuring audit continuity.</remarks>
+        /// <param name="document">The document containing mutation and run blocks to be applied as part of the transaction.</param>
+        /// <param name="dryRun">If <see langword="true"/>, simulates the transaction without persisting any changes or creating a log entry;
+        /// otherwise, applies and commits the mutations.</param>
+        /// <param name="progress">An optional progress reporter that receives status messages as the transaction progresses. May be <see
+        /// langword="null"/>.</param>
+        /// <param name="options">Optional settings that control transaction behavior, such as base mismatch handling and run block timeouts. May
+        /// be <see langword="null"/>.</param>
+        /// <param name="ct">A cancellation token that can be used to cancel the transaction operation.</param>
+        /// <returns>A <see cref="DispatchResult"/> indicating the outcome of the transaction, including success status, resulting
+        /// handle, error messages, and a list of operation results.</returns>
+        /// <exception cref="DxException">Thrown if a run block fails during the commit-gate phase or if an invalid argument is encountered in a run
+        /// block.</exception>
+        private async Task<DispatchResult> ExecuteMutatingTransactionAsync(
+                    DxDocument document,
+                    bool dryRun,
+                    IProgress<string>? progress,
+                    ApplyOptions? options,
+                    CancellationToken ct)
     {
         var lockFile = Path.Combine(_workspaceRoot, ".dx", "snaps.lock");
         await using var dxLock = await DxLock.AcquireAsync(lockFile, TimeSpan.FromSeconds(5), ct);
@@ -107,94 +133,62 @@ public sealed class DxDispatcher
         var coordinator = new TransactionCoordinator(_connection, _workspaceRoot, _ignoreSet, _logger);
         var operations = new List<OperationResult>();
 
-        try
+        return await coordinator.RunAsync(_sessionId, async (tx, innerCt) =>
         {
-            return await coordinator.RunAsync(_sessionId, async (tx, innerCt) =>
+            var currentHead = await GetCurrentHeadAsync(innerCt);
+
+            if (document.Header.Base is { } baseHandle)
             {
-                var currentHead = await GetCurrentHeadAsync(innerCt);
-
-                // Authoritative Base Enforcement
-                if (document.Header.Base is { } baseHandle)
+                var baseHash = HandleAssigner.Resolve(_connection, _sessionId, baseHandle);
+                if (baseHash == null || !DxHash.Equal(baseHash, currentHead))
                 {
-                    var baseHash = HandleAssigner.Resolve(_connection, _sessionId, baseHandle);
-                    if (baseHash == null || !DxHash.Equal(baseHash, currentHead))
+                    var actual = HandleAssigner.ReverseResolve(_connection, _sessionId, currentHead) ?? "?";
+                    var message = $"Base mismatch. Expected: {baseHandle}, Actual: {actual}";
+
+                    if (options?.OnBaseMismatch?.ToLowerInvariant() != "warn")
                     {
-                        var actual = HandleAssigner.ReverseResolve(_connection, _sessionId, currentHead) ?? "?";
-                        var message = $"Base mismatch. Expected: {baseHandle}, Actual: {actual}";
-
-                        if (options?.OnBaseMismatch?.ToLowerInvariant() != "warn")
-                        {
-                            // Ensure failure is logged to session_log for audit
-                            await AppendLogAsync(tx, document, null, false, innerCt);
-
-                            // Return IsBaseMismatch: true to trigger Exit Code 3 in CLI
-                            return new DispatchResult(false, null, message, operations, IsBaseMismatch: true);
-                        }
-                        _logger.Warn(message);
+                        return new DispatchResult(false, null, message, operations, IsBaseMismatch: true);
                     }
+                    _logger.Warn(message);
                 }
+            }
 
-                if (dryRun)
-                {
-                    _logger.Info("Dry run — state mutation suppressed. No log entry created.");
-                    return new DispatchResult(true, null, null, operations);
-                }
+            if (dryRun) return new DispatchResult(true, null, null, operations);
 
-                // Execution Phase: Apply mutations
-                foreach (var block in document.Blocks.Where(IsMutation))
-                {
-                    innerCt.ThrowIfCancellationRequested();
-                    progress?.Report($"Applying {block.GetType().Name}...");
-                    await DispatchMutationBlockAsync(block, operations, innerCt);
-                }
+            foreach (var block in document.Blocks.Where(IsMutating))
+            {
+                innerCt.ThrowIfCancellationRequested();
+                await DispatchMutationBlockAsync(block, operations, innerCt);
+            }
 
-                // Gate Phase: Run-blocks act as commit-gates
-                var runTimeout = options?.RunTimeoutSeconds ?? 0;
-                foreach (var run in document.Blocks.OfType<RequestBlock>().Where(r => r.Type == "run"))
-                {
-                    innerCt.ThrowIfCancellationRequested();
-                    var (exitCode, output) = await ExecuteRunAsync(run.Body.Trim(), runTimeout, innerCt);
-                    operations.Add(OperationResult.Create("REQUEST:run", null, exitCode == 0, output));
-                    if (exitCode != 0) throw new DxException(DxError.InvalidArgument, $"Gate failed: {output}");
-                }
+            var runTimeout = options?.RunTimeoutSeconds ?? 0;
+            foreach (var run in document.Blocks.OfType<RequestBlock>().Where(r => r.Type == "run"))
+            {
+                innerCt.ThrowIfCancellationRequested();
+                var (exitCode, output) = await ExecuteRunAsync(run.Body.Trim(), runTimeout, innerCt);
+                operations.Add(OperationResult.Create("REQUEST:run", null, exitCode == 0, output));
+                if (exitCode != 0) throw new DxException(DxError.InvalidArgument, $"Gate failed: {output}");
+            }
 
-                // Snapshot & Commit Phase
-                var manifest = ManifestBuilder.Build(_workspaceRoot, _ignoreSet);
-                var snapHash = ManifestBuilder.ComputeSnapHash(manifest);
+            var manifest = ManifestBuilder.Build(_workspaceRoot, _ignoreSet);
+            var snapHash = ManifestBuilder.ComputeSnapHash(manifest);
 
-                string newHandle;
+            string newHandle;
+            bool isCheckout = document.Blocks.Any(b => b is FsBlock fs && fs.Op == "checkout");
 
-                // Detect checkout as a mutation that requires a log entry
-                bool isCheckout = document.Blocks.Any(b => b is FsBlock fs && fs.Op == "checkout");
+            if (DxHash.Equal(snapHash, currentHead) && !isCheckout)
+            {
+                newHandle = HandleAssigner.ReverseResolve(_connection, _sessionId, currentHead)!;
+            }
+            else
+            {
+                var writer = new SnapshotWriter(_connection);
+                newHandle = await writer.PersistAsync(_sessionId, snapHash, manifest, innerCt, tx);
+            }
 
-                if (DxHash.Equal(snapHash, currentHead) && !isCheckout)
-                {
-                    newHandle = HandleAssigner.ReverseResolve(_connection, _sessionId, currentHead)!;
-                }
-                else
-                {
-                    var writer = new SnapshotWriter(_connection);
-                    newHandle = await writer.PersistAsync(_sessionId, snapHash, manifest, innerCt, tx);
-                }
-
-                // Sole authoritative success log. 
-                // Creates exactly one log entry marked with success=true.
-                await AppendLogAsync(tx, document, newHandle, true, innerCt);
-                _logger.Info($"→ {newHandle}");
-
-                return new DispatchResult(true, newHandle, null, operations);
-            }, ct);
-        }
-        catch(DxException dx) when(dx.Error == DxError.BaseMismatch)
-        {
-            await AppendLogAsync(null, document, null, false, ct);
-            return new DispatchResult(false, null, dx.Message, operations, IsBaseMismatch: true);
-        }
-        catch (Exception ex)
-        {
-            await AppendLogAsync(null, document, null, false, ct);
-            return new DispatchResult(false, null, ex.Message, operations);
-        }
+            _logger.Info($"→ {newHandle}");
+            return new DispatchResult(true, newHandle, null, operations);
+        }, ct);
     }
 
     private async Task DispatchMutationBlockAsync(DxBlock block, List<OperationResult> ops, CancellationToken ct)
@@ -390,7 +384,7 @@ public sealed class DxDispatcher
     {
         var (shell, args) = GetShell(command);
 
-        var psi = new System.Diagnostics.ProcessStartInfo
+        var psi = new ProcessStartInfo
         {
             FileName = shell,
             Arguments = args,
@@ -503,13 +497,7 @@ public sealed class DxDispatcher
         return abs;
     }
 
-    private static bool IsMutation(DxBlock b) => b switch
-    {
-        FileBlock f => !f.ReadOnly,
-        PatchBlock => true,
-        FsBlock => true,
-        _ => false,
-    };
+    private static bool IsMutating(DxBlock block) => block.IsMutating;
 
     private static Encoding ResolveEncoding(string enc) => enc.ToLowerInvariant() switch
     {
@@ -538,10 +526,13 @@ public sealed class DxDispatcher
     {
         if (bytes.Length >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF)
             return new UTF8Encoding(true);
+
         if (bytes.Length >= 2 && bytes[0] == 0xFF && bytes[1] == 0xFE)
             return Encoding.Unicode;
+        
         if (bytes.Length >= 2 && bytes[0] == 0xFE && bytes[1] == 0xFF)
             return Encoding.BigEndianUnicode;
+        
         return new UTF8Encoding(false);
     }
 
@@ -551,6 +542,7 @@ public sealed class DxDispatcher
         if (preamble.Length == 0) return bytes;
         if (bytes.AsSpan().StartsWith(preamble))
             return bytes[preamble.Length..];
+
         return bytes;
     }
 

--- a/src/Dx.Core/Protocol/DxExecutionRequest.cs
+++ b/src/Dx.Core/Protocol/DxExecutionRequest.cs
@@ -6,62 +6,36 @@ using Dx.Core.Protocol;
 namespace Dx.Core.Execution;
 
 /// <summary>
-/// Represents the complete, immutable execution request
-/// for a DX operation crossing the protocol boundary.
+/// Represents a fully encapsulated request to execute a DX document.
 /// </summary>
 /// <remarks>
 /// <para>
-/// <see cref="DxExecutionRequest"/> is the sole input contract
-/// for all DX execution. No execution path may bypass this type.
+/// This record acts as the execution envelope, separating the semantic model 
+/// (<see cref="Document"/>) from the authoritative intent (<see cref="RawText"/>) 
+/// and accountability metadata (<see cref="Direction"/>).
 /// </para>
 /// <para>
-/// This object is intentionally immutable and validated at
-/// construction time to prevent partial or inconsistent execution.
+/// <strong>Boundary:</strong>
+/// This type is the only location where execution intent 
+/// (<see cref="RawText"/>) and accountability metadata 
+/// (<see cref="Direction"/>) are stored.
+/// </para>
+/// <para>
+/// These values must not be copied into semantic models 
+/// (<see cref="DxDocument"/>) or execution outcomes 
+/// (<see cref="DxResult"/>).
 /// </para>
 /// </remarks>
-public sealed class DxExecutionRequest
+public sealed record DxExecutionRequest(
+    DxDocument Document,
+    string RawText,
+    string Direction,
+    DxExecutionMode Mode,
+    bool IsDryRun, // This property is redundant but included for convenience and clarity.
+    IProgress<string>? Progress,
+    ApplyOptions? Options,
+    CancellationToken CancellationToken)
 {
-    /// <summary>Gets the parsed DX document to execute.</summary>
-    public DxDocument Document { get; }
-
-    /// <summary>Gets the execution mode.</summary>
-    public DxExecutionMode Mode { get; }
-
-    /// <summary>Gets the optional progress reporter.</summary>
-    public IProgress<string>? Progress { get; }
-
-    /// <summary>Gets the optional execution overrides.</summary>
-    public ApplyOptions? Options { get; }
-
-    /// <summary>Gets the cancellation token for this execution.</summary>
-    public CancellationToken CancellationToken { get; }
-
-    /// <summary>
-    /// Initializes a new <see cref="DxExecutionRequest"/>.
-    /// </summary>
-    /// <param name="document">The parsed DX document.</param>
-    /// <param name="mode">The execution mode.</param>
-    /// <param name="progress">Optional progress sink.</param>
-    /// <param name="options">Optional per-invocation overrides.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <exception cref="ArgumentNullException">
-    /// Thrown when <paramref name="document"/> is null.
-    /// </exception>
-    public DxExecutionRequest(
-        DxDocument document,
-        DxExecutionMode mode,
-        IProgress<string>? progress = null,
-        ApplyOptions? options = null,
-        CancellationToken ct = default)
-    {
-        ArgumentNullException.ThrowIfNull(document);
-        Document = document;
-        Mode = mode;
-        Progress = progress;
-        Options = options;
-        CancellationToken = ct;
-    }
-
     /// <summary>
     /// Gets a value indicating whether this request is a dry run.
     /// </summary>
@@ -72,6 +46,8 @@ public sealed class DxExecutionRequest
     /// (e.g. <c>var (document, mode, isDryRun, progress, options, ct) = request;</c>).
     /// </summary>
     /// <param name="document">When this method returns, contains the value of the Document property.</param>
+    /// <param name="rawText">When this method returns, contains the value of the RawText property.</param>
+    /// <param name="direction">When this method returns, contains the value of the Direction
     /// <param name="mode">When this method returns, contains the value of the Mode property.</param>
     /// <param name="isDryRun">When this method returns, contains a value indicating whether the operation is a dry run.</param>
     /// <param name="progress">When this method returns, contains the progress reporter, or null if not set.</param>
@@ -79,6 +55,8 @@ public sealed class DxExecutionRequest
     /// <param name="ct">When this method returns, contains the cancellation token associated with the operation.</param>
     public void Deconstruct(
         out DxDocument document,
+        out string rawText,
+        out string direction,
         out DxExecutionMode mode,
         out bool isDryRun,
         out IProgress<string>? progress,
@@ -86,6 +64,8 @@ public sealed class DxExecutionRequest
         out CancellationToken ct)
     {
         document = Document;
+        rawText = RawText;
+        direction = Direction;
         mode = Mode;
         isDryRun = IsDryRun;
         progress = Progress;

--- a/src/Dx.Core/Protocol/DxIR.cs
+++ b/src/Dx.Core/Protocol/DxIR.cs
@@ -78,7 +78,16 @@ public sealed record DxHeader(
 /// Abstract base type for all block nodes in a parsed DX document's IR (Intermediate
 /// Representation). Each concrete block type corresponds to a <c>%%TOKEN</c> delimiter.
 /// </summary>
-public abstract record DxBlock;
+public abstract record DxBlock
+{
+    public bool IsMutating => this switch
+    {
+        FileBlock f => !f.ReadOnly,
+        PatchBlock => true,
+        FsBlock fs => fs.Op is "move" or "delete" or "encode" or "restore" or "checkout",
+        _ => false
+    };
+}
 
 /// <summary>
 /// Represents a <c>%%FILE</c> block that writes or declares a workspace file.

--- a/src/Dx.Core/Protocol/DxProtocolDispatcher.cs
+++ b/src/Dx.Core/Protocol/DxProtocolDispatcher.cs
@@ -68,16 +68,16 @@ public sealed class DxProtocolDispatcher
 
         try
         {
-            DispatchResult raw = await _engine.DispatchAsync(request);
+            DispatchResult legacyResult = await _engine.DispatchAsync(request);
 
-            if (raw is null)
+            if (legacyResult is null)
             {
                 throw new InvalidOperationException(
                     "Dispatch engine returned null. This violates the execution contract.");
             }
 
-            return DxResultMapper.FromDispatchResult(
-                raw,
+            return DxResultMapper.ToDxResult(
+                legacyResult,
                 request.Mode == DxExecutionMode.DryRun);
         }
         catch (OperationCanceledException) when (request.CancellationToken.IsCancellationRequested)

--- a/src/Dx.Core/Protocol/DxResultLoggingSerializer.cs
+++ b/src/Dx.Core/Protocol/DxResultLoggingSerializer.cs
@@ -1,0 +1,68 @@
+namespace Dx.Core.Protocol;
+
+using Dx.Core.Execution.Results;
+
+using System.Text;
+
+/// <summary>
+/// Provides deterministic, byte-stable serialization of <see cref="DxResult"/> instances 
+/// specifically for authoritative session logging.
+/// </summary>
+/// <remarks>
+/// This serializer is strictly reserved for the <c>session_log</c> audit trail. It ensures that 
+/// the outcome of every execution is recorded in a canonical DX format that is decoupled 
+/// from CLI presentation logic and human-readable formatting.
+/// </remarks>
+public static class DxResultLoggingSerializer
+{
+    /// <summary>
+    /// Serializes a <see cref="DxResult"/> into a canonical DX document string for logging.
+    /// </summary>
+    /// <param name="result">The execution result to serialize.</param>
+    /// <returns>
+    /// A <see langword="string"/> containing the DX-formatted result document.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if <paramref name="result"/> is <see langword="null"/>.
+    /// </exception>
+    public static string Serialize(DxResult result)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+
+        var sb = new StringBuilder();
+
+        sb.AppendLine("%%DX v1.3 type=result");
+
+        sb.Append("%%RESULT ");
+        sb.Append($"success={(result.IsSuccess ? "true" : "false")} ");
+        sb.Append($"committed={(result.IsCommitted ? "true" : "false")} ");
+
+        if (result.SnapId is not null)
+        {
+            sb.Append($"snap={result.SnapId} ");
+        }
+
+        if (!string.IsNullOrWhiteSpace(result.Message))
+        {
+            sb.Append($"error=\"{Escape(result.Message)}\"");
+        }
+
+        sb.AppendLine();
+
+        foreach (var block in result.Blocks)
+        {
+            sb.AppendLine($"%%BLOCK path=\"{block.Path ?? ""}\" status={(block.Success ? "applied" : "failed")}");
+            if (!string.IsNullOrWhiteSpace(block.Detail))
+            {
+                sb.AppendLine($"    {block.Detail}");
+            }
+            sb.AppendLine("%%ENDBLOCK");
+        }
+
+        sb.AppendLine("%%END");
+        return sb.ToString();
+    }
+
+    private static string Escape(string value) =>
+        value.Replace("\"", "\\\"").Replace("\r", "").Replace("\n", " ");
+}

--- a/src/Dx.Core/Protocol/DxResultLoggingSerializer.cs
+++ b/src/Dx.Core/Protocol/DxResultLoggingSerializer.cs
@@ -9,9 +9,15 @@ using System.Text;
 /// specifically for authoritative session logging.
 /// </summary>
 /// <remarks>
-/// This serializer is strictly reserved for the <c>session_log</c> audit trail. It ensures that 
-/// the outcome of every execution is recorded in a canonical DX format that is decoupled 
-/// from CLI presentation logic and human-readable formatting.
+/// <para>
+/// <strong>Determinism Contract:</strong>
+/// The output of this serializer must be byte-stable for a given 
+/// <see cref="DxResult"/>.
+/// </para>
+/// <para>
+/// Do not introduce ordering based on runtime state, collections 
+/// with unstable iteration order, timestamps, or environment variables.
+/// </para>
 /// </remarks>
 public static class DxResultLoggingSerializer
 {
@@ -34,6 +40,7 @@ public static class DxResultLoggingSerializer
         sb.AppendLine("%%DX v1.3 type=result");
 
         sb.Append("%%RESULT ");
+        sb.Append($"status={result.Status.ToString().ToLowerInvariant()} ");
         sb.Append($"success={(result.IsSuccess ? "true" : "false")} ");
         sb.Append($"committed={(result.IsCommitted ? "true" : "false")} ");
 
@@ -49,20 +56,65 @@ public static class DxResultLoggingSerializer
 
         sb.AppendLine();
 
-        foreach (var block in result.Blocks)
+        if (result.Metadata?.Count > 0)
         {
-            sb.AppendLine($"%%BLOCK path=\"{block.Path ?? ""}\" status={(block.Success ? "applied" : "failed")}");
-            if (!string.IsNullOrWhiteSpace(block.Detail))
+            sb.AppendLine("%%METADATA");
+            foreach (var kvp in result.Metadata.OrderBy(k => k.Key))
             {
-                sb.AppendLine($"    {block.Detail}");
+                sb.AppendLine($"    {kvp.Key}: {FormatValue(kvp.Value)}");
             }
-            sb.AppendLine("%%ENDBLOCK");
+            sb.AppendLine("%%ENDMETADATA");
+        }
+
+        foreach (var op in result.Blocks)
+        {
+            SerializeOperation(op, sb);
         }
 
         sb.AppendLine("%%END");
         return sb.ToString();
     }
 
+    private static void SerializeOperation(OperationResult op, StringBuilder sb)
+    {
+        string baseType = op.BlockType.Split(':')[0].ToUpperInvariant();
+        string tag = baseType switch
+        {
+            "FILE" => "%%FILE",
+            "PATCH" => "%%PATCH",
+            "FS" => "%%FS",
+            "REQUEST" => "%%REQUEST",
+            _ => "%%BLOCK"
+        };
+
+        sb.Append($"{tag} ");
+        if (!string.IsNullOrWhiteSpace(op.Path)) sb.Append($"path=\"{op.Path}\" ");
+        sb.Append($"status={(op.Success ? "applied" : "failed")}");
+        sb.AppendLine();
+
+        if (!string.IsNullOrWhiteSpace(op.Detail))
+        {
+            var lines = op.Detail.Split(new[] { "\n", "\r\n" }, StringSplitOptions.None);
+            foreach (var line in lines)
+            {
+                sb.AppendLine($"    {line}");
+            }
+        }
+
+        sb.AppendLine("%%ENDBLOCK");
+    }
+
+    private static string FormatValue(object? val) => val switch
+    {
+        null => "null",
+        string s => $"\"{Escape(s)}\"",
+        bool b => b ? "true" : "false",
+        _ => val.ToString() ?? "null"
+    };
+
     private static string Escape(string value) =>
-        value.Replace("\"", "\\\"").Replace("\r", "").Replace("\n", " ");
+        value.Replace("\\", "\\\\")
+             .Replace("\"", "\\\"")
+             .Replace("\r", "")
+             .Replace("\n", " ");
 }

--- a/src/Dx.Core/Storage/DxStore.cs
+++ b/src/Dx.Core/Storage/DxStore.cs
@@ -1,0 +1,51 @@
+using Dapper;
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Dx.Core.Storage;
+
+public partial class DxStore : IDxStore
+{
+    /// <summary>
+    /// Persists a canonical I/O record to the SQLite-backed session log.
+    /// </summary>
+    /// <param name="entry">The structured log entry.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>A <see cref="Task"/> representing completion.</returns>
+    /// <remarks>
+    /// The <c>session_log</c> is the authoritative source of truth for workspace history.
+    /// Every entry is timestamped by the database to ensure a monotonic audit trail.
+    /// </remarks>
+    public async Task WriteSessionLogAsync(SessionLogEntry entry, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+
+        const string sql = @"
+            INSERT INTO session_log (
+                direction, 
+                document, 
+                tx_success, 
+                snap_handle, 
+                created_at
+            ) 
+            VALUES (
+                @Direction, 
+                @Document, 
+                @TxSuccess, 
+                @SnapHandle, 
+                STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')
+            );";
+
+        await _connection.ExecuteAsync(new CommandDefinition(
+            sql,
+            new
+            {
+                entry.Direction,
+                entry.Document,
+                entry.TxSuccess,
+                entry.SnapHandle
+            },
+            cancellationToken: ct));
+    }
+}

--- a/src/Dx.Core/Storage/DxStore.cs
+++ b/src/Dx.Core/Storage/DxStore.cs
@@ -1,12 +1,28 @@
 using Dapper;
 
+using Microsoft.Data.Sqlite;
+
+using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace Dx.Core.Storage;
 
-public partial class DxStore : IDxStore
+/// <summary>
+/// Provides access to a session log backed by a SQLite database, enabling persistent storage and retrieval of canonical
+/// I/O records for workspace history.
+/// </summary>
+/// <remarks>The session log serves as the authoritative record of workspace activity, with each entry timestamped
+/// by the database to ensure a reliable and monotonic audit trail. This class is not thread-safe; callers should ensure
+/// appropriate synchronization if accessed concurrently.</remarks>
+/// <param name="connection">The open SQLite connection used to interact with the session log database. Cannot be null.</param>
+public partial class DxStore(
+    SqliteConnection connection,
+    string sessionId) : IDxStore
 {
+    private readonly SqliteConnection _connection = connection;
+    private readonly string _sessionId = sessionId;
+
     /// <summary>
     /// Persists a canonical I/O record to the SQLite-backed session log.
     /// </summary>
@@ -23,17 +39,19 @@ public partial class DxStore : IDxStore
 
         const string sql = @"
             INSERT INTO session_log (
-                direction, 
-                document, 
-                tx_success, 
-                snap_handle, 
+                session_id,
+                direction,
+                document,
+                tx_success,
+                snap_handle,
                 created_at
-            ) 
+            )
             VALUES (
-                @Direction, 
-                @Document, 
-                @TxSuccess, 
-                @SnapHandle, 
+                @SessionId,
+                @Direction,
+                @Document,
+                @TxSuccess,
+                @SnapHandle,
                 STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')
             );";
 
@@ -41,6 +59,7 @@ public partial class DxStore : IDxStore
             sql,
             new
             {
+                SessionId = _sessionId,
                 entry.Direction,
                 entry.Document,
                 entry.TxSuccess,

--- a/src/Dx.Core/Storage/SessionLogEntry.cs
+++ b/src/Dx.Core/Storage/SessionLogEntry.cs
@@ -1,0 +1,28 @@
+namespace Dx.Core.Storage;
+
+/// <summary>
+/// Represents a discrete entry in the authoritative <c>session_log</c>.
+/// </summary>
+public sealed class SessionLogEntry
+{
+    /// <summary>
+    /// Gets or sets the actor responsible for the document (e.g., "llm", "tool").
+    /// </summary>
+    public required string Direction { get; init; }
+
+    /// <summary>
+    /// Gets or sets the byte-accurate raw document content or serialized result.
+    /// </summary>
+    public required string Document { get; init; }
+
+    /// <summary>
+    /// Gets or sets the transaction success indicator. 
+    /// Use <see langword="null"/> for input logs, <c>1</c> for success, or <c>0</c> for failure.
+    /// </summary>
+    public int? TxSuccess { get; init; }
+
+    /// <summary>
+    /// Gets or sets the resulting snapshot handle if the execution modified state.
+    /// </summary>
+    public string? SnapHandle { get; init; }
+}

--- a/src/Dx.Core/Storage/SessionLogEntry.cs
+++ b/src/Dx.Core/Storage/SessionLogEntry.cs
@@ -3,8 +3,13 @@ namespace Dx.Core.Storage;
 /// <summary>
 /// Represents a discrete entry in the authoritative <c>session_log</c>.
 /// </summary>
-public sealed class SessionLogEntry
+public sealed record SessionLogEntry
 {
+    /// <summary>
+    /// Gets the unique identifier for the session.
+    /// </summary>
+    public required string SessionId { get; init; }
+
     /// <summary>
     /// Gets or sets the actor responsible for the document (e.g., "llm", "tool").
     /// </summary>

--- a/src/Dx.Core/Storage/SqliteContentStore.cs
+++ b/src/Dx.Core/Storage/SqliteContentStore.cs
@@ -4,10 +4,20 @@ using Microsoft.Data.Sqlite;
 
 namespace Dx.Core.Storage;
 
-using Microsoft.Data.Sqlite;
+using System.Threading;
+using System.Threading.Tasks;
 
-using Dapper;
-
+public partial interface IDxStore
+{
+    /// <summary>
+    /// Appends a new entry to the <c>session_log</c> table.
+    /// </summary>
+    /// <param name="entry">The log entry data.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="entry"/> is <see langword="null"/>.</exception>
+    Task WriteSessionLogAsync(SessionLogEntry entry, CancellationToken ct = default);
+}
 /// <summary>
 /// Provides high-performance, content-addressed storage of raw file bytes using 
 /// SQLite's Incremental BLOB I/O.

--- a/tests/Dx.Core.Tests/Execution/Results/DxProtocolDispatcherTests.cs
+++ b/tests/Dx.Core.Tests/Execution/Results/DxProtocolDispatcherTests.cs
@@ -23,8 +23,8 @@ public sealed class DxProtocolDispatcherTests
 
         var dispatcher = new DxProtocolDispatcher(engine);
 
-        var doc = CreateDocument();
-        var request = new DxExecutionRequest(doc, DxExecutionMode.Apply);
+        var document = CreateDocument();
+        var request = CreateRequest(document);
 
         DxResult result = await dispatcher.ExecuteAsync(request);
 
@@ -45,7 +45,7 @@ public sealed class DxProtocolDispatcherTests
                 IsBaseMismatch: true));
 
         var dispatcher = new DxProtocolDispatcher(engine);
-        var request = new DxExecutionRequest(CreateDocument(), DxExecutionMode.Apply);
+        var request = CreateRequest(CreateDocument());
 
         DxResult result = await dispatcher.ExecuteAsync(request);
 
@@ -65,7 +65,7 @@ public sealed class DxProtocolDispatcherTests
                 IsBaseMismatch: false));
 
         var dispatcher = new DxProtocolDispatcher(engine);
-        var request = new DxExecutionRequest(CreateDocument(), DxExecutionMode.Apply);
+        var request = CreateRequest(CreateDocument(), DxExecutionMode.Apply);
 
         DxResult result = await dispatcher.ExecuteAsync(request);
 
@@ -77,7 +77,7 @@ public sealed class DxProtocolDispatcherTests
     public async Task ExecuteAsync_Should_Handle_Exception()
     {
         var dispatcher = new DxProtocolDispatcher(new ThrowingEngine());
-        var request = new DxExecutionRequest(CreateDocument(), DxExecutionMode.Apply);
+        var request = CreateRequest(CreateDocument(), DxExecutionMode.Apply);
 
         DxResult result = await dispatcher.ExecuteAsync(request);
 
@@ -115,5 +115,20 @@ public sealed class DxProtocolDispatcherTests
     {
         public Task<DispatchResult> DispatchAsync(DxExecutionRequest request)
             => throw new InvalidOperationException("Boom");
+    }
+
+    private static DxExecutionRequest CreateRequest(
+        DxDocument document,
+        DxExecutionMode mode = DxExecutionMode.Apply)
+    {
+        return new DxExecutionRequest(
+            Document: document,
+            RawText: "/* test input */",
+            Direction: "test",
+            Mode: mode,
+            IsDryRun: false,
+            Progress: null,
+            Options: null,
+            CancellationToken: default);
     }
 }

--- a/tests/Dx.Core.Tests/SessionLogInvariantsTests.cs
+++ b/tests/Dx.Core.Tests/SessionLogInvariantsTests.cs
@@ -1,0 +1,277 @@
+using Dapper;
+
+using Dx.Core;
+using Dx.Core.Execution;
+using Dx.Core.Protocol;
+using Dx.Core.Storage;
+
+using Microsoft.Data.Sqlite;
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Xunit;
+
+namespace Dx.Core.Tests.Protocol;
+
+/// <summary>
+/// Enforces the foundational DX protocol invariants established in PR 43.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Architectural Lock:</strong>
+/// These tests do not verify block execution logic. They verify the 
+/// <em>observability and audit contracts</em> of the dispatcher.
+/// </para>
+/// <para>
+/// Do not mock the database or the dispatcher for these tests. They must 
+/// interact with a real SQLite connection to guarantee schema and transaction 
+/// integrity.
+/// </para>
+/// </remarks>
+public class SessionLogInvariantsTests : IAsyncLifetime
+{
+    private SqliteConnection _connection = null!;
+    private DxDispatcher _dispatcher = null!;
+    private readonly string _sessionId = "test-session";
+    private string _workspaceRoot = null!; // Use a real temp path
+
+    public async Task InitializeAsync()
+    {
+        // 1. Create a unique, real workspace for this test run
+        _workspaceRoot = Path.Combine(Path.GetTempPath(), $"dx_test_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_workspaceRoot);
+
+        // IMPORTANT: The dispatcher looks for .dx/ for locking and metadata
+        Directory.CreateDirectory(Path.Combine(_workspaceRoot, ".dx"));
+
+        // 2. Setup SQLite
+        _connection = new SqliteConnection("Data Source=:memory:");
+        await _connection.OpenAsync();
+        DxDatabase.Migrate(_connection);
+
+        // 3. Setup Genesis Session & Snap (Required for Base Resolution)
+        await _connection.ExecuteAsync(
+            "INSERT INTO sessions (session_id, root, created_utc) VALUES (@sid, @root, @t)",
+            new { sid = _sessionId, root = _workspaceRoot, t = DxDatabase.UtcNow() });
+
+        // Create the dummy T0000 so the dispatcher can resolve the 'base'
+        var dummyHash = new byte[32];
+        await _connection.ExecuteAsync("INSERT INTO snaps (snap_hash, created_utc) VALUES (@h, @t)", new { h = dummyHash, t = DxDatabase.UtcNow() });
+        await _connection.ExecuteAsync(
+            "INSERT INTO snap_handles (session_id, handle, snap_hash, seq, created_utc) VALUES (@sid, 'T0000', @h, 0, @t)",
+            new { sid = _sessionId, h = dummyHash, t = DxDatabase.UtcNow() });
+        await _connection.ExecuteAsync(
+            "INSERT INTO session_state (session_id, head_snap_hash, updated_utc) VALUES (@sid, @h, @t)",
+            new { sid = _sessionId, h = dummyHash, t = DxDatabase.UtcNow() });
+
+        // 4. Initialize Dispatcher with Mandatory IgnoreSet
+        // This is what prevents the "snaps.lock" FileLoadException
+        var ignoreSet = IgnoreSetFactory.Create(null, Array.Empty<string>(), false);
+        var store = new DxStore(_connection, _sessionId);
+
+        _dispatcher = new DxDispatcher(
+            _connection,
+            store,
+            _workspaceRoot,
+            ignoreSet,
+            _sessionId);
+    }
+
+    public Task DisposeAsync()
+    {
+        _connection?.Dispose();
+
+        // Cleanup the physical workspace
+        if (!string.IsNullOrEmpty(_workspaceRoot) && Directory.Exists(_workspaceRoot))
+        {
+            try { Directory.Delete(_workspaceRoot, true); } catch { /* ignore cleanup errors */ }
+        }
+
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task DualLogInvariant_MutatingDocument_WritesExactlyTwoLogs_WithCorrectTxSuccessState()
+    {
+        // Arrange
+        var request = CreateTestRequest(isMutating: true);
+
+        // Act
+        var result = await _dispatcher.DispatchAsync(request);
+
+        // Assert
+        if (!result.IsSuccess)
+        {
+            var errors = string.Join(", ", result.Diagnostics.Select(d => d.Message));
+            throw new Exception($"Dispatch failed: {result.Message}. Diagnostics: {errors}");
+        }
+
+        var logs = GetSessionLogs();
+
+        Assert.Equal(2, logs.Count);
+
+        // Log 1: Input Intent (T-Success is NULL)
+        Assert.Null(logs[0].TxSuccess);
+
+        // Log 2: Execution Outcome (T-Success is 1)
+        Assert.Equal(1, logs[1].TxSuccess);
+        Assert.NotNull(logs[1].SnapHandle);
+        Assert.Equal("T0001", logs[1].SnapHandle);
+    }
+
+    [Fact]
+    public async Task CausalOrdering_LogsAreWrittenInChronologicalOrder_InputBeforeResult()
+    {
+        var request = CreateTestRequest(isMutating: true);
+        await _dispatcher.DispatchAsync(request);
+
+        var logs = GetSessionLogs();
+
+        Assert.Equal(2, logs.Count);
+        Assert.True(logs[0].Id < logs[1].Id, "Causal ID ordering failed.");
+
+        // Fix CS0019: Use string.CompareOrdinal or parse to DateTime
+        Assert.True(string.CompareOrdinal(logs[0].CreatedAt, logs[1].CreatedAt) <= 0,
+            "Input timestamp must not be later than Result timestamp.");
+    }
+
+    [Fact]
+    public async Task TriStateSemantics_FailingMutation_LogsTxSuccessAsZero()
+    {
+        // Arrange: A request designed to fail via BaseMismatch (expects T9999, actual is T0000)
+        var request = CreateFailingTestRequest();
+
+        // Act
+        await _dispatcher.DispatchAsync(request);
+
+        // Assert
+        var logs = GetSessionLogs();
+
+        Assert.Equal(2, logs.Count);
+
+        // Input log is still preserved despite failure
+        Assert.Null(logs[0].TxSuccess);
+
+        // Outcome log explicitly marks failure (0) and yields no snapshot
+        Assert.Equal(0, logs[1].TxSuccess);
+        Assert.Null(logs[1].SnapHandle);
+    }
+
+    [Fact]
+    public async Task ReadOnlyExecution_LogsExecutionButDoesNotCommitState()
+    {
+        // Arrange
+        var request = CreateTestRequest(isMutating: false);
+
+        // Act
+        await _dispatcher.DispatchAsync(request);
+
+        // Assert
+        var logs = GetSessionLogs();
+
+        Assert.Equal(2, logs.Count);
+
+        // Outcome log is successful, but explicitly produces NO snapshot
+        Assert.Equal(1, logs[1].TxSuccess);
+        Assert.Null(logs[1].SnapHandle);
+    }
+
+    [Fact]
+    public async Task CheckoutInvariant_OutsideDispatcher_WritesExactlyOneSuccessfulLog()
+    {
+        // Arrange & Act
+        // Because DxRuntime.CheckoutAsync operates on physical files, we simulate the
+        // exact DB call it makes in this black-box, in-memory DB test to verify the schema.
+        await _connection.ExecuteAsync(
+            "INSERT INTO session_log (session_id, direction, document, snap_handle, tx_success, created_at) " +
+            "VALUES (@sid, 'tool', '(checkout T0000)', 'T0000', 1, @t)",
+            new { sid = _sessionId, t = DxDatabase.UtcNow() });
+
+        // Assert
+        var logs = GetSessionLogs();
+
+        Assert.Single(logs);
+        Assert.Equal("tool", logs[0].Direction);
+        Assert.Equal(1, logs[0].TxSuccess);
+        Assert.NotNull(logs[0].SnapHandle);
+        Assert.Contains("checkout", logs[0].Document);
+    }
+
+    // --- Test Helpers ---
+
+    /// <summary>
+    /// Dedicated DTO for reading back the full table including auto-generated columns.
+    /// </summary>
+    private sealed class TestLogEntry
+    {
+        public long Id { get; set; }
+        public string Direction { get; set; } = "";
+        public string Document { get; set; } = "";
+        public int? TxSuccess { get; set; }
+        public string? SnapHandle { get; set; }
+        public string CreatedAt { get; set; } = "";
+    }
+
+    private List<TestLogEntry> GetSessionLogs()
+    {
+        return _connection.Query<TestLogEntry>(
+            "SELECT id as Id, direction as Direction, tx_success as TxSuccess, snap_handle as SnapHandle, " +
+            "created_at as CreatedAt, document as Document " +
+            "FROM session_log ORDER BY id ASC"
+        ).ToList();
+    }
+
+    private DxExecutionRequest CreateTestRequest(bool isMutating)
+    {
+        var header = new DxHeader("1.3", _sessionId, "user", "test", "T0000", null, null, !isMutating, null);
+        var blocks = new List<DxBlock>();
+
+        if (isMutating)
+        {
+            blocks.Add(new FileBlock("test.txt", "utf-8", false, null, true, null, null, "data"));
+        }
+        else
+        {
+            blocks.Add(new NoteBlock("just reading"));
+        }
+
+        var doc = new DxDocument(header, blocks);
+
+        return new DxExecutionRequest(
+            Document: doc,
+            RawText: "%%DX v1.3\n" + (isMutating ? "%%FILE path=\"test.txt\"\ndata\n%%ENDBLOCK\n" : "%%NOTE\njust reading\n%%ENDBLOCK\n"),
+            Direction: "user",
+            Mode: DxExecutionMode.Apply,
+            IsDryRun: false,
+            Progress: null,
+            Options: new ApplyOptions(),
+            CancellationToken: CancellationToken.None
+        );
+    }
+
+    private DxExecutionRequest CreateFailingTestRequest()
+    {
+        // Require a base that doesn't match HEAD (T9999) to force a fast protocol failure
+        var header = new DxHeader("1.3", _sessionId, "user", "test", "T9999", null, null, false, null);
+        var blocks = new List<DxBlock>
+        {
+            new FileBlock("fail.txt", "utf-8", false, null, true, null, null, "data")
+        };
+
+        var doc = new DxDocument(header, blocks);
+
+        return new DxExecutionRequest(
+            Document: doc,
+            RawText: "%%DX v1.3 base=T9999\n%%FILE path=\"fail.txt\"\ndata\n%%ENDBLOCK\n",
+            Direction: "user",
+            Mode: DxExecutionMode.Apply,
+            IsDryRun: false,
+            Progress: null,
+            Options: new ApplyOptions(OnBaseMismatch: "reject"),
+            CancellationToken: CancellationToken.None
+        );
+    }
+}

--- a/tests/foundation-tests.sh
+++ b/tests/foundation-tests.sh
@@ -119,34 +119,6 @@ check "dxs init: -s names session"     0 "my-session"          init "$WORKSPACE2
 [[ -d "$WORKSPACE/.dx" ]] \
     && pass "init: .dx dir created" || fail "init: .dx dir missing"
 
-# ── 24. Invariant: checkout logging (#14) ────────────────────────────────────
-
-section "24. Invariant: checkout logging"
-
-# Checkout is a state mutation and MUST produce a session_log entry.
-# Strategy:
-#   1. Record the log count before checkout
-#   2. Perform a checkout
-#   3. Assert log count increased by exactly 1
-#   4. Assert the new entry has tx_success = ✓ and a snap handle
-
-LOG_COUNT_BEFORE=$(dxs log -r "$WORKSPACE" -n 1000 2>&1 | grep -cE '✓|✗' || true)
-
-# Perform a checkout (go to T0000, then back to something else)
-dxs snap checkout T0000 -r "$WORKSPACE" > /dev/null 2>&1
-
-LOG_COUNT_AFTER=$(dxs log -r "$WORKSPACE" -n 1000 2>&1 | grep -cE '✓|✗' || true)
-
-[[ "$LOG_COUNT_AFTER" -gt "$LOG_COUNT_BEFORE" ]] \
-    && pass "checkout log: session_log entry added after checkout" \
-    || fail "checkout log: no new session_log entry after checkout (invariant violation)"
-
-# The most recent entry should be successful (tx_success=1)
-LATEST_LOG=$(dxs log -r "$WORKSPACE" -n 1 2>&1)
-echo "$LATEST_LOG" | grep -qE '✓' \
-    && pass "checkout log: most recent entry is successful" \
-    || fail "checkout log: most recent entry is not successful"
-
 # ── 2. dxs snap list / show ────────────────────────────────────────────────────────
 
 section "2. dxs snap list / show"
@@ -749,6 +721,34 @@ echo "$NEW_SESSION_LOG" | grep -qE '✓' \
     || fail "genesis log: new session has no genesis log entry"
 
 dxs session close log-invariant-test -r "$WORKSPACE" > /dev/null 2>&1
+
+# ── 24. Invariant: checkout logging (#14) ────────────────────────────────────
+
+section "24. Invariant: checkout logging"
+
+# Checkout is a state mutation and MUST produce a session_log entry.
+# Strategy:
+#   1. Record the log count before checkout
+#   2. Perform a checkout
+#   3. Assert log count increased by exactly 1
+#   4. Assert the new entry has tx_success = ✓ and a snap handle
+
+LOG_COUNT_BEFORE=$(dxs log -r "$WORKSPACE" -n 1000 2>&1 | grep -cE '✓|✗' || true)
+
+# Perform a checkout (go to T0000, then back to something else)
+dxs snap checkout T0000 -r "$WORKSPACE" > /dev/null 2>&1
+
+LOG_COUNT_AFTER=$(dxs log -r "$WORKSPACE" -n 1000 2>&1 | grep -cE '✓|✗' || true)
+
+[[ "$LOG_COUNT_AFTER" -gt "$LOG_COUNT_BEFORE" ]] \
+    && pass "checkout log: session_log entry added after checkout" \
+    || fail "checkout log: no new session_log entry after checkout (invariant violation)"
+
+# The most recent entry should be successful (tx_success=1)
+LATEST_LOG=$(dxs log -r "$WORKSPACE" -n 1 2>&1)
+echo "$LATEST_LOG" | grep -qE '✓' \
+    && pass "checkout log: most recent entry is successful" \
+    || fail "checkout log: most recent entry is not successful"
 
 # ── 25. Invariant: DoctorCommand mapping (#12) ───────────────────────────────
 


### PR DESCRIPTION
## Summary
Finalize the dual‑log observability model by aligning protocol, runtime, CLI, and database schema so every execution produces a canonical input log and result log.

## Related Issue
Closes #32

## Type of Change
- [x] Refactor
- [x] Behavioral change
- [x] Tests

## Changes
- Enforced DxExecutionRequest as the execution envelope.
- Finalized DxResult as an immutable terminal result.
- Centralized canonical input/result logging.
- Made session_log.tx_success nullable to support intent vs outcome logs.
- Updated CLI and protocol tests to consume DxResult.

## Invariants / Contracts
- Exactly two log entries per execution (input + result).
- NULL tx_success denotes intent; 0/1 denotes outcome.
- Checkout logs exactly one successful mutation.

## Verification
All foundation and protocol tests pass; manual CLI verification completed.

## Risks
Schema migration makes tx_success nullable; existing data preserved.

## Checklist
- [x] Builds cleanly
- [x] Tests pass
- [x] No regression in CLI behavior
- [x] Logging consistency preserved